### PR TITLE
[TASK] Recommende static_info_tables >= 6.3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "typo3-ter/oelib": "self.version"
     },
     "suggest": {
-        "sjbr/static-info-tables": "^6.2.0"
+        "sjbr/static-info-tables": "^6.3.7"
     },
     "autoload": {
         "classmap": [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -42,7 +42,7 @@ $EM_CONF[$_EXTKEY] = [
         'conflicts' => [
         ],
         'suggests' => [
-            'static_info_tables' => '6.2.0-',
+            'static_info_tables' => '6.3.7-',
         ],
     ],
     'autoload' => [


### PR DESCRIPTION
This is the earliest version available on Packagist.