### PR TITLE
[BUGFIX] Make SalutationSwitcher/TemplateHelper serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - remove obsolete TypoScript files (#8)
 
 ### Fixed
+- Allow serialization of FE plugins for mkforms caching (#43)
 - Make the geocoding compatible with TYPO3 8LTS (#39)
 - Provide cli_dispatch.phpsh for 8.7 on Travis (#37)
 - Fix the DataMapper tests in TYPO3 8.7 (#32)

--- a/Classes/SalutationSwitcher.php
+++ b/Classes/SalutationSwitcher.php
@@ -1,5 +1,6 @@
 <?php
 
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Plugin\AbstractPlugin;
 use TYPO3\CMS\Lang\LanguageService;
@@ -44,6 +45,34 @@ abstract class Tx_Oelib_SalutationSwitcher extends AbstractPlugin
             $this->availableLanguages, $this->suffixesToTry, $this->conf,
             $this->pi_EPtemp_cObj, $this->cObj, $this->LOCAL_LANG
         );
+    }
+
+    /**
+     * Makes this object serializable.
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        $fieldsToSave = \get_object_vars($this);
+        unset($fieldsToSave['frontendController'], $fieldsToSave['databaseConnection']);
+
+        return \array_keys($fieldsToSave);
+    }
+
+    /**
+     * Restores data that got lost during the serialization.
+     *
+     * @return void
+     */
+    public function __wakeup()
+    {
+        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 7006000) {
+            return;
+        }
+
+        $this->databaseConnection = \Tx_Oelib_Db::getDatabaseConnection();
+        $this->frontendController = $this->getFrontEndController();
     }
 
     /**

--- a/Tests/Unit/SalutationSwitcherTest.php
+++ b/Tests/Unit/SalutationSwitcherTest.php
@@ -31,6 +31,14 @@ class Tx_Oelib_Tests_Unit_SalutationSwitcherTest extends \Tx_Phpunit_TestCase
         $this->testingFramework->cleanUp();
     }
 
+    /**
+     * @test
+     */
+    public function canBeSerialized()
+    {
+        static::assertNotSame('', serialize($this->subject));
+    }
+
     ////////////////////////////////////
     // Tests for setting the language.
     ////////////////////////////////////


### PR DESCRIPTION
This fixes a crash when mkforms tries to serialize the content object for
caching.