### PR TITLE
[BUGFIX] Drop the Composer dependency on emogrifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - remove obsolete TypoScript files (#8)
 
 ### Fixed
+- Drop the Composer dependency on emogrifier (#49)
 - Increase the delay when over the geocoding query limit (#47)
 - Allow serialization of FE plugins for mkforms caching (#43)
 - Make the geocoding compatible with TYPO3 8LTS (#39)

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "php": "^5.5.0 || ~7.0.0",
         "typo3/cms-core": "^6.2.14 || ^7.6.23",
         "typo3/cms-frontend": "^6.2.14 || ^7.6.23",
-        "typo3/cms-fluid": "^6.2.14 || ^7.6.23",
-        "pelago/emogrifier": "^2.0.0"
+        "typo3/cms-fluid": "^6.2.14 || ^7.6.23"
     },
     "require-dev": {
         "sjbr/static-info-tables": "^6.3.7",


### PR DESCRIPTION
This fixes installation of this extension in TYPO3 6.2.