### PR TITLE
[FOLLOWUP] Drop deprecated mailer functions

### DIFF
--- a/Tests/Unit/AbstractMailerTest.php
+++ b/Tests/Unit/AbstractMailerTest.php
@@ -31,15 +31,8 @@ class Tx_Oelib_Tests_Unit_AbstractMailerTest extends \Tx_Phpunit_TestCase
         'headers' => '',
     ];
 
-    /**
-     * @var bool
-     */
-    protected $deprecationLogEnabledBackup = false;
-
     protected function setUp()
     {
-        $this->deprecationLogEnabledBackup = $GLOBALS['TYPO3_CONF_VARS']['SYS']['enableDeprecationLog'];
-
         $this->subject = new \Tx_Oelib_EmailCollector();
 
         $this->message1 = $this->getMock(MailMessage::class, ['send']);
@@ -52,8 +45,6 @@ class Tx_Oelib_Tests_Unit_AbstractMailerTest extends \Tx_Phpunit_TestCase
         GeneralUtility::makeInstance(MailMessage::class);
 
         $this->subject->cleanUp();
-
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['enableDeprecationLog'] = $this->deprecationLogEnabledBackup;
     }
 
     /*

--- a/Tests/Unit/MailerFactoryTest.php
+++ b/Tests/Unit/MailerFactoryTest.php
@@ -15,22 +15,9 @@ class Tx_Oelib_Tests_Unit_MailerFactoryTest extends \Tx_Phpunit_TestCase
      */
     protected $subject = null;
 
-    /**
-     * @var bool
-     */
-    protected $deprecationLogEnabledBackup = false;
-
     protected function setUp()
     {
-        $this->deprecationLogEnabledBackup = $GLOBALS['TYPO3_CONF_VARS']['SYS']['enableDeprecationLog'];
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['enableDeprecationLog'] = false;
-
         $this->subject = new \Tx_Oelib_MailerFactory();
-    }
-
-    protected function tearDown()
-    {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['enableDeprecationLog'] = $this->deprecationLogEnabledBackup;
     }
 
     /*


### PR DESCRIPTION
In the unit tests, the deprecation log now does not need to be disabled
anymore.