### PR TITLE
[BUGFIX] Update the composer package name of static-info-tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Update the composer package name of static-info-tables (#85)
 
 ## 2.0.1
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "typo3/cms-fluid": "^7.6.23 || ^8.7.9"
     },
     "require-dev": {
-        "sjbr/static-info-tables": "^6.4.0",
+        "typo3-ter/static-info-tables": "^6.4.0",
         "oliverklee/user-oelibtest": "@dev",
         "oliverklee/user-oelibtest2": "@dev",
 
@@ -43,7 +43,7 @@
         "typo3-ter/oelib": "self.version"
     },
     "suggest": {
-        "sjbr/static-info-tables": "^6.4.0"
+        "typo3-ter/static-info-tables": "^6.4.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
The old package sjbr/static-info-tables has been abandoned.
typo3-ter/static-info-tables should be used instead.