### PR TITLE
[BUGFIX] Rework the geocoding throttling

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+0.9.5 - released 2018-10-10
+
+Bug fixes:
+- Rework the geocoding throttling (#87, #90)
+
 0.9.4 - released 2018-04-23
 
 Features:


### PR DESCRIPTION
The geocoding now starts with delay of 100ms and will stay under 120s
(the timeout for PHPUnit on Travis).

This is the 0.9.x backport part for #87.