### PR TITLE
[BUGFIX] Remove the "sensor" parameter from the Google geocoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Remove the "sensor" parameter from the Google geocoding (#101)
 - Rework the geocoding throttling (#87, #96)
 - Make the unit tests not depend on the current time of day (#57)
 

--- a/Classes/Geocoding/Google.php
+++ b/Classes/Geocoding/Google.php
@@ -26,7 +26,7 @@ class Tx_Oelib_Geocoding_Google implements \Tx_Oelib_Interface_GeocodingLookup
      *
      * @var string
      */
-    const BASE_URL = 'https://maps.google.com/maps/api/geocode/json?sensor=false';
+    const BASE_URL = 'https://maps.googleapis.com/maps/api/geocode/json';
 
     /**
      * the Singleton instance
@@ -128,7 +128,7 @@ class Tx_Oelib_Geocoding_Google implements \Tx_Oelib_Interface_GeocodingLookup
         $address = $geoObject->getGeoAddress();
         $configuration = Tx_Oelib_ConfigurationRegistry::get('plugin.tx_oelib');
         $apiKey = $configuration->getAsString('googleGeocodingApiKey');
-        $url = self::BASE_URL . '&key=' . \urlencode($apiKey) . '&address=' . \urlencode($address);
+        $url = self::BASE_URL . '?key=' . \urlencode($apiKey) . '&address=' . \urlencode($address);
         $delayInMicroseconds = self::INITIAL_DELAY_IN_MICROSECONDS;
 
         while (true) {

--- a/Tests/Unit/Geocoding/GoogleTest.php
+++ b/Tests/Unit/Geocoding/GoogleTest.php
@@ -269,8 +269,8 @@ class GoogleTest extends \Tx_Phpunit_TestCase
         $this->configuration->setAsString('googleGeocodingApiKey', $apiKey);
 
         $address = 'Am Hof 1, 53113 Zentrum, Bonn, DE';
-        $expectedUrl = 'https://maps.google.com/maps/api/geocode/json?sensor=false' .
-            '&key=' . $apiKey .
+        $expectedUrl = 'https://maps.googleapis.com/maps/api/geocode/json' .
+            '?key=' . $apiKey .
             '&address=' . \urlencode($address);
 
         $jsonResult = '{ "results": [ { "address_components": [ { "long_name": "1", "short_name": "1", ' .


### PR DESCRIPTION
Also update the domain in the API URL.