### PR TITLE
[BUGFIX] Remove the "sensor" parameter from the Google geocoding

### DIFF
--- a/Classes/Geocoding/Google.php
+++ b/Classes/Geocoding/Google.php
@@ -24,7 +24,7 @@ class tx_oelib_Geocoding_Google implements \tx_oelib_Interface_GeocodingLookup
      *
      * @var string
      */
-    const BASE_URL = 'https://maps.google.com/maps/api/geocode/json?sensor=false';
+    const BASE_URL = 'https://maps.googleapis.com/maps/api/geocode/json';
 
     /**
      * the Singleton instance
@@ -114,7 +114,7 @@ class tx_oelib_Geocoding_Google implements \tx_oelib_Interface_GeocodingLookup
         $address = $geoObject->getGeoAddress();
         $configuration = Tx_Oelib_ConfigurationRegistry::get('plugin.tx_oelib');
         $apiKey = $configuration->getAsString('googleGeocodingApiKey');
-        $url = self::BASE_URL . '&key=' . \urlencode($apiKey) . '&address=' . \urlencode($address);
+        $url = self::BASE_URL . '?key=' . \urlencode($apiKey) . '&address=' . \urlencode($address);
         $delayInMicroseconds = self::INITIAL_DELAY_IN_MICROSECONDS;
 
         while (true) {

--- a/Tests/Unit/Geocoding/GoogleTest.php
+++ b/Tests/Unit/Geocoding/GoogleTest.php
@@ -246,8 +246,8 @@ class Tx_Oelib_Tests_Unit_Geocoding_GoogleTest extends Tx_Phpunit_TestCase
         $this->configuration->setAsString('googleGeocodingApiKey', $apiKey);
 
         $address = 'Am Hof 1, 53113 Zentrum, Bonn, DE';
-        $expectedUrl = 'https://maps.google.com/maps/api/geocode/json?sensor=false' .
-            '&key=' . $apiKey .
+        $expectedUrl = 'https://maps.googleapis.com/maps/api/geocode/json' .
+            '?key=' . $apiKey .
             '&address=' . \urlencode($address);
 
         $jsonResult = '{ "results": [ { "address_components": [ { "long_name": "1", "short_name": "1", ' .

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+0.9.6 (unreleased)
+
+Bug fixes:
+- Remove the "sensor" parameter from the Google geocoding (#102)
+
 0.9.5 - released 2018-10-11
 
 Features:


### PR DESCRIPTION
Also update the domain in the API URL.