### PR TITLE
[TASK] Drop roave/security-advisories from the dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop roave/security-advisories from the dev dependencies (#118)
 
 ### Fixed
 - Add required PHP extension to the composer.json (#88, #110)


### PR DESCRIPTION
This dependency should only be in the project `composer.json`,
not in the dependency libraries.