### PR TITLE
[FEATURE] Starter tests with nimut/testing-framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: php
 env:
   global:
   - DATABASE_USER=travis DATABASE_HOST=localhost DATABASE_PORT=3306 DATABASE_NAME=typo3 DATABASE_PASSWORD=''
+  - typo3DatabaseUsername=travis typo3DatabaseHost=localhost typo3DatabaseName=3306 typo3DatabaseName=typo3 typo3DatabasePassword=''
   - TYPO3_PATH_ROOT=$PWD/.Build/public
 
 cache:
@@ -40,21 +41,23 @@ script:
 - >
   echo;
   echo "Running the unit tests";
+  composer ci:tests:unit;
+- >
+  echo;
+  echo "Running the legacy unit tests";
   composer ci:tests:unit-legacy;
 - >
   echo;
   echo "Running the functional tests";
+  composer ci:tests:functional;
+- >
+  echo;
+  echo "Running the legacy functional tests";
   composer ci:tests:functional-legacy;
 
 jobs:
   include:
   - stage: test
-    php: 7.2
-    env: TYPO3=^8.7 RUN_TESTS_COMMAND=".Build/vendor/bin/typo3 phpunit:run"
-  - stage: test
-    php: 7.2
-    env: TYPO3=^8.7 DEPENDENCIES_PREFERENCE="--prefer-lowest" SYMFONY_CONSOLE="symfony/console:^3.2" RUN_TESTS_COMMAND=".Build/vendor/bin/typo3 phpunit:run"
-  - stage: test
     php: 7.1
     env: TYPO3=^8.7 RUN_TESTS_COMMAND=".Build/vendor/bin/typo3 phpunit:run"
   - stage: test
@@ -66,12 +69,6 @@ jobs:
   - stage: test
     php: 7.0
     env: TYPO3=^8.7 DEPENDENCIES_PREFERENCE="--prefer-lowest" SYMFONY_CONSOLE="symfony/console:^3.2" RUN_TESTS_COMMAND=".Build/vendor/bin/typo3 phpunit:run"
-  - stage: test
-    php: 7.2
-    env: TYPO3=^7.6 RUN_TESTS_COMMAND=".Build/public/typo3/cli_dispatch.phpsh phpunit"
-  - stage: test
-    php: 7.2
-    env: TYPO3=^7.6 DEPENDENCIES_PREFERENCE="--prefer-lowest" RUN_TESTS_COMMAND=".Build/public/typo3/cli_dispatch.phpsh phpunit"
   - stage: test
     php: 7.1
     env: TYPO3=^7.6 RUN_TESTS_COMMAND=".Build/public/typo3/cli_dispatch.phpsh phpunit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z (unreleased)
 
 ### Added
+- Starter tests with nimut/testing-framework (#129)
 - Test both with the lowest and highest dependency versions (#121)
 - Add a configuration for the Google Maps API key (#92, #112)
 

--- a/Tests/Functional/HelloWorldTest.php
+++ b/Tests/Functional/HelloWorldTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OliverKlee\Oelib\Tests\Functional;
+
+use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+
+/**
+ * Test case.
+ *
+ * @author Oliver Klee <typo3-coding@oliverklee.de>
+ */
+class HelloWorldTest extends FunctionalTestCase
+{
+    /**
+     * @var string[]
+     */
+    protected $testExtensionsToLoad = ['typo3conf/ext/oelib'];
+
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function timeSpaceContinuumWorksFine()
+    {
+        static::assertSame(2, 1 + 1);
+    }
+}

--- a/Tests/Unit/HelloWorldTest.php
+++ b/Tests/Unit/HelloWorldTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OliverKlee\Oelib\Tests\Unit;
+
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+
+/**
+ * Test case.
+ *
+ * @author Oliver Klee <typo3-coding@oliverklee.de>
+ */
+class HelloWorldTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function timeSpaceContinuumWorksFine()
+    {
+        static::assertSame(2, 1 + 1);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "helhum/typo3-console": "^4.9",
 
         "oliverklee/phpunit": "^5.3",
+        "nimut/testing-framework": "^2.0",
         "phpunit/phpunit": "^5.6",
         "mikey179/vfsStream": "^1.6",
 
@@ -82,10 +83,14 @@
     },
     "scripts": {
         "ci:php:lint": "find *.php Classes/ Configuration/ TestExtensions/ Tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
+        "ci:tests:unit": "phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit/",
         "ci:tests:unit-legacy": "$RUN_TESTS_COMMAND Tests/LegacyUnit/",
+        "ci:tests:functional": "phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml Tests/Functional/",
         "ci:tests:functional-legacy": "$RUN_TESTS_COMMAND Tests/LegacyFunctional/",
         "ci:tests": [
+            "@ci:tests:unit",
             "@ci:tests:unit-legacy",
+            "@ci:tests:functional",
             "@ci:tests:functional-legacy"
         ],
         "ci:dynamic": [
@@ -111,6 +116,7 @@
             "dev-master": "2.1.x-dev"
         },
         "typo3/cms": {
+            "extension-key": "oelib",
             "cms-package-dir": "{$vendor-dir}/typo3/cms",
             "web-dir": ".Build/public"
         },


### PR DESCRIPTION
Also drop the 7.2 builds from Travis as the version of the testing framework
that still uses PHPUnit 5.x (which the PHPUnit extension currently provides)
does not work with PHP 7.2.