### PR TITLE
[TASK] Drop an obsolete comment

### DIFF
--- a/Classes/MapperRegistry.php
+++ b/Classes/MapperRegistry.php
@@ -7,8 +7,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * the directory Mapper/ in each extension. Extension can use mappers from
  * other extensions as well.
  *
- * Note: This does not work with user_ extensions yet.
- *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 class Tx_Oelib_MapperRegistry


### PR DESCRIPTION
Mapper class names now do not have any restrictions anymore.

[ci skip]