### PR TITLE
[BUGFIX] Only clean up tables that have a dummy column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Only clean up tables that have a dummy column (#168)
 - Use the current composer names of static_info_tables (#127)
 
 ## 1.5.0

--- a/Classes/TestingFramework.php
+++ b/Classes/TestingFramework.php
@@ -869,31 +869,24 @@ final class Tx_Oelib_TestingFramework
     private function cleanUpTableSet($useSystemTables, $performDeepCleanUp)
     {
         if ($useSystemTables) {
-            $tablesToCleanUp = $performDeepCleanUp
-                ? $this->allowedSystemTables
-                : $this->dirtySystemTables;
+            $tablesToCleanUp = $performDeepCleanUp ? $this->allowedSystemTables : $this->dirtySystemTables;
         } else {
-            $tablesToCleanUp = $performDeepCleanUp
-                ? $this->ownAllowedTables
-                : $this->dirtyTables;
+            $tablesToCleanUp = $performDeepCleanUp ? $this->ownAllowedTables : $this->dirtyTables;
         }
 
         foreach ($tablesToCleanUp as $currentTable) {
             $dummyColumnName = $this->getDummyColumnName($currentTable);
+            if (!\Tx_Oelib_Db::tableHasColumn($currentTable, $dummyColumnName)) {
+                continue;
+            }
 
-            // Runs a delete query for each allowed table. A
-            // "one-query-deletes-them-all" approach was tested but we didn't
-            // find a working solution for that.
-            \Tx_Oelib_Db::delete(
-                $currentTable,
-                $dummyColumnName . ' = 1'
-            );
+            // Runs a delete query for each allowed table. A "one-query-deletes-them-all" approach was tested,
+            // but we didn't find a working solution for that.
+            \Tx_Oelib_Db::delete($currentTable, $dummyColumnName . ' = 1');
 
-            // Resets the auto increment setting of the current table.
             $this->resetAutoIncrementLazily($currentTable);
         }
 
-        // Resets the list of dirty tables.
         $this->dirtyTables = [];
     }
 


### PR DESCRIPTION
This makes sure that during a deep cleanup, own tables without a dummy
column (e.g., new static tables) will not get cleaned up by the
testing framework.