### PR TITLE
[BUGFIX] Only clean up tables that have a dummy column

### DIFF
--- a/Classes/TestingFramework.php
+++ b/Classes/TestingFramework.php
@@ -829,33 +829,26 @@ final class Tx_Oelib_TestingFramework {
 	 * @return void
 	 */
 	protected function cleanUpTableSet($useSystemTables, $performDeepCleanUp) {
-		if ($useSystemTables) {
-			$tablesToCleanUp = ($performDeepCleanUp)
-				? $this->allowedSystemTables
-				: $this->dirtySystemTables;
-		} else {
-			$tablesToCleanUp = ($performDeepCleanUp)
-				? $this->ownAllowedTables
-				: $this->dirtyTables;
-		}
+        if ($useSystemTables) {
+            $tablesToCleanUp = $performDeepCleanUp ? $this->allowedSystemTables : $this->dirtySystemTables;
+        } else {
+            $tablesToCleanUp = $performDeepCleanUp ? $this->ownAllowedTables : $this->dirtyTables;
+        }
 
-		foreach ($tablesToCleanUp as $currentTable) {
-			$dummyColumnName = $this->getDummyColumnName($currentTable);
+        foreach ($tablesToCleanUp as $currentTable) {
+            $dummyColumnName = $this->getDummyColumnName($currentTable);
+            if (!\Tx_Oelib_Db::tableHasColumn($currentTable, $dummyColumnName)) {
+                continue;
+            }
 
-			// Runs a delete query for each allowed table. A
-			// "one-query-deletes-them-all" approach was tested but we didn't
-			// find a working solution for that.
-			Tx_Oelib_Db::delete(
-				$currentTable,
-				$dummyColumnName . ' = 1'
-			);
+            // Runs a delete query for each allowed table. A "one-query-deletes-them-all" approach was tested,
+            // but we didn't find a working solution for that.
+            \Tx_Oelib_Db::delete($currentTable, $dummyColumnName . ' = 1');
 
-			// Resets the auto increment setting of the current table.
-			$this->resetAutoIncrementLazily($currentTable);
-		}
+            $this->resetAutoIncrementLazily($currentTable);
+        }
 
-		// Resets the list of dirty tables.
-		$this->dirtyTables = array();
+        $this->dirtyTables = [];
 	}
 
 	/**

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 0.9.7 (unreleased)
 
+Bug fixes:
+- Only clean up tables that have a dummy column (#169)
+
 0.9.6 - released 2018-10-12
 
 Features:


### PR DESCRIPTION
This makes sure that during a deep cleanup, own tables without a dummy
column (e.g., new static tables) will not get cleaned up by the
testing framework.