### PR TITLE
[BUGFIX] Allow mixed-case configuration check class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow mixed-case configuration check class names (#185)
 - Only clean up tables that have a dummy column (#168)
 - Use the current composer names of static_info_tables (#127)
 

--- a/Classes/TemplateHelper.php
+++ b/Classes/TemplateHelper.php
@@ -116,19 +116,59 @@ class Tx_Oelib_TemplateHelper extends \Tx_Oelib_SalutationSwitcher
         }
 
         $this->ensureContentObject();
-        $this->pi_setPiVarDefaults();
-        $this->pi_loadLL();
 
-        if (($this->extKey !== '')
-            && \Tx_Oelib_ConfigurationProxy::getInstance($this->extKey)
-                ->getAsBoolean('enableConfigCheck')) {
-            $configurationCheckClassName = 'tx_' . $this->extKey . '_configcheck';
-            if (class_exists($configurationCheckClassName, true)) {
-                $this->configurationCheck = GeneralUtility::makeInstance($configurationCheckClassName, $this);
-            }
+        if ($this->extKey !== '') {
+            $this->pi_setPiVarDefaults();
+            $this->pi_loadLL();
+            $this->initializeConfigurationCheck();
         }
 
         $this->isInitialized = true;
+    }
+
+    /**
+     * @return void
+     */
+    protected function initializeConfigurationCheck()
+    {
+        if (!$this->isConfigurationCheckEnabled()) {
+            return;
+        }
+
+        $className = $this->getConfigurationCheckClassName();
+        if ($className !== '') {
+            $this->configurationCheck = GeneralUtility::makeInstance($className, $this);
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isConfigurationCheckEnabled()
+    {
+        if ($this->extKey === '') {
+            return false;
+        }
+
+        return \Tx_Oelib_ConfigurationProxy::getInstance($this->extKey)->getAsBoolean('enableConfigCheck');
+    }
+
+    /**
+     * @return string might be empty
+     */
+    protected function getConfigurationCheckClassName()
+    {
+        $camelCaseClassName = 'Tx_' . ucfirst($this->extKey) . '_ConfigCheck';
+        $lowercaseClassName = \strtolower($camelCaseClassName);
+        if (\class_exists($camelCaseClassName)) {
+            $className = $camelCaseClassName;
+        } elseif (\class_exists($lowercaseClassName)) {
+            $className = $lowercaseClassName;
+        } else {
+            $className = '';
+        }
+
+        return $className;
     }
 
     /**


### PR DESCRIPTION
This works around inconsistencies between different autoloaders.