### PR TITLE
[BUGFIX] Ignore relations with a foreign UID of 0

### DIFF
--- a/Tests/Functional/DataMapperTest.php
+++ b/Tests/Functional/DataMapperTest.php
@@ -133,6 +133,22 @@ class Tx_Oelib_Tests_Functional_DataMapperTest extends Tx_Phpunit_TestCase {
 		);
 	}
 
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
+    public function silentlyIgnoresCommaSeparatedOneToManyRelationWithZeroForeignUid()
+    {
+        $uid = $this->testingFramework->createRecord(
+            'tx_oelib_test',
+            ['children' => '0']
+        );
+        /** @var \Tx_Oelib_Tests_Unit_Fixtures_TestingModel $model */
+        $model = $this->subject->find($uid);
+        // load any property to trigger loading the data
+        $model->getTitle();
+    }
+
 	/*
 	 * Tests concerning the m:n mapping using an m:n table
 	 */
@@ -157,6 +173,20 @@ class Tx_Oelib_Tests_Functional_DataMapperTest extends Tx_Phpunit_TestCase {
 			$firstRelatedModel->getTitle()
 		);
 	}
+
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
+    public function silentlyIgnoresManyToManyRelationWithZeroForeignUid()
+    {
+        $uid = $this->testingFramework->createRecord('tx_oelib_test', ['related_records' => 1]);
+        $this->testingFramework->createRecord('tx_oelib_test_article_mm', ['uid_local' => $uid, 'uid_foreign' => 0]);
+        /** @var \Tx_Oelib_Tests_Unit_Fixtures_TestingModel $model */
+        $model = $this->subject->find($uid);
+        // load any property to trigger loading the data
+        $model->getTitle();
+    }
 
 	/*
 	 * Tests concerning the bidirectional m:n mapping using an m:n table.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 0.9.7 (unreleased)
 
 Bug fixes:
+- Ignore relations with a foreign UID of 0 (#197)
 - Only clean up tables that have a dummy column (#169)
 
 0.9.6 - released 2018-10-12


### PR DESCRIPTION
This is the 0.9.x backport of #194.