### PR TITLE
[BUGFIX] Prevent rounding errors with the coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Prevent rounding errors with the coordinates (#208, #209, #210)
 
 ## 2.3.0
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -5,8 +5,8 @@ CREATE TABLE tx_oelib_domain_model_germanzipcode (
 
     zip_code varchar(5) DEFAULT '' NOT NULL,
     city_name varchar(255) DEFAULT '' NOT NULL,
-    longitude float(9,6) DEFAULT '0.000000' NOT NULL,
-    latitude float(9,6) DEFAULT '0.000000' NOT NULL,
+    longitude decimal(9,6) DEFAULT '0.000000' NOT NULL,
+    latitude decimal(9,6) DEFAULT '0.000000' NOT NULL,
 
     PRIMARY KEY (uid),
     KEY parent (pid),

--- a/ext_tables_static+adt.sql
+++ b/ext_tables_static+adt.sql
@@ -6,8 +6,8 @@ CREATE TABLE tx_oelib_domain_model_germanzipcode (
 
     zip_code varchar(5) DEFAULT '' NOT NULL,
     city_name varchar(255) DEFAULT '' NOT NULL,
-    longitude float(9,6) DEFAULT '0.000000' NOT NULL,
-    latitude float(9,6) DEFAULT '0.000000' NOT NULL,
+    longitude decimal(9,6) DEFAULT '0.000000' NOT NULL,
+    latitude decimal(9,6) DEFAULT '0.000000' NOT NULL,
 
     PRIMARY KEY (uid),
     KEY parent (pid),


### PR DESCRIPTION
The geo coordinates need to be saved as decimal, not as float.