### PR TITLE
[BUGFIX] Prevent rounding errors with the coordinates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+0.9.x - not released yet
+
+Bug fixes:
+- Prevent rounding errors with the coordinates (#208, #209, #210)
+
 0.9.8 - released 2019-03-13
 
 Features:

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -5,8 +5,8 @@ CREATE TABLE tx_oelib_domain_model_germanzipcode (
 
 	zip_code varchar(5) DEFAULT '' NOT NULL,
 	city_name varchar(255) DEFAULT '' NOT NULL,
-	longitude float(9,6) DEFAULT '0.000000' NOT NULL,
-	latitude float(9,6) DEFAULT '0.000000' NOT NULL,
+	longitude decimal(9,6) DEFAULT '0.000000' NOT NULL,
+	latitude decimal(9,6) DEFAULT '0.000000' NOT NULL,
 
 	PRIMARY KEY (uid),
 	KEY parent (pid),

--- a/ext_tables_static+adt.sql
+++ b/ext_tables_static+adt.sql
@@ -6,8 +6,8 @@ CREATE TABLE tx_oelib_domain_model_germanzipcode (
 
     zip_code varchar(5) DEFAULT '' NOT NULL,
     city_name varchar(255) DEFAULT '' NOT NULL,
-    longitude float(9,6) DEFAULT '0.000000' NOT NULL,
-    latitude float(9,6) DEFAULT '0.000000' NOT NULL,
+    longitude decimal(9,6) DEFAULT '0.000000' NOT NULL,
+    latitude decimal(9,6) DEFAULT '0.000000' NOT NULL,
 
     PRIMARY KEY (uid),
     KEY parent (pid),


### PR DESCRIPTION
The geo coordinates need to be saved as decimal, not as float.