### PR TITLE
[BUGFIX] Always initialize a BE user in the BE user manager tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Always initialize a BE user in the BE user manager tests (#220)
 - Explicitly require MySQL on Travis CI (#219)
 - Remove dependency on specific FE-user extensions (#213, #214)
 - Prevent rounding errors with the coordinates (#208, #209, #210)

--- a/Tests/LegacyUnit/BackEndLoginManagerTest.php
+++ b/Tests/LegacyUnit/BackEndLoginManagerTest.php
@@ -3,6 +3,7 @@
 use OliverKlee\Oelib\Tests\Unit\Mapper\Fixtures\TestingMapper;
 use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\TestingModel;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Core\Bootstrap;
 
 /**
  * Test case.
@@ -28,8 +29,8 @@ class Tx_Oelib_Tests_LegacyUnit_BackEndLoginManagerTest extends \Tx_Phpunit_Test
 
     protected function setUp()
     {
+        Bootstrap::getInstance()->initializeBackendAuthentication();
         $this->testingFramework = new \Tx_Oelib_TestingFramework('tx_oelib');
-
         $this->backEndUserMapper = \Tx_Oelib_MapperRegistry::get(\Tx_Oelib_Mapper_BackEndUser::class);
 
         $this->subject = \Tx_Oelib_BackEndLoginManager::getInstance();


### PR DESCRIPTION
This fixes the tests with PHPUnit 5.7.