### PR TITLE
[TASK] Streamline the composer.json dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Streamline the composer.json dependencies (#221)
 - Always initialize a BE user in the BE user manager tests (#220)
 - Explicitly require MySQL on Travis CI (#219)
 - Remove dependency on specific FE-user extensions (#213, #214)

--- a/composer.json
+++ b/composer.json
@@ -42,16 +42,13 @@
         "oliverklee/phpunit": "^5.3",
         "nimut/testing-framework": "^2.0",
         "phpunit/phpunit": "^5.6",
-        "mikey179/vfsstream": "^1.6",
-
-        "roave/security-advisories": "dev-master"
+        "mikey179/vfsstream": "^1.6"
     },
     "conflict": {
         "sjbr/static-info-tables": "6.7.1",
         "typo3/cms-composer-installers": "<1.4.6"
     },
     "replace": {
-        "oelib": "self.version",
         "typo3-ter/oelib": "self.version"
     },
     "suggest": {


### PR DESCRIPTION
- drop an obsolete `replace` entry
- the the dependency on `roave/security-advisories` as this should
  be in the distribution, not the individual extensions