### PR TITLE
[TASK] Mark Db::getDatabaseConnection for removal in version 4.0, not 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add PHP-CS-Fixer rules for PHPUnit (#226)
 
 ### Changed
+- Mark Db::getDatabaseConnection for removal in version 4.0, not 3.0 (#228)
 - Upgrade to PHPUnit 5.7 (#223)
 - Change from GPL V3 to GPL V2+ (#221)
 - Move more tests to Tests/Unit/ and Tests/Functional/ (#212)

--- a/Classes/Db.php
+++ b/Classes/Db.php
@@ -739,7 +739,7 @@ class Tx_Oelib_Db
     /**
      * Returns $GLOBALS['TYPO3_DB'].
      *
-     * @deprecated will be removed in oelib 3.0
+     * @deprecated will be removed in oelib 4.0
      *
      * @return DatabaseConnection
      */

--- a/Classes/Domain/Repository/Traits/ReadOnlyTrait.php
+++ b/Classes/Domain/Repository/Traits/ReadOnlyTrait.php
@@ -5,7 +5,7 @@ namespace OliverKlee\Oelib\Domain\Repository\Traits;
 /**
  * This trait marks repositories as read-only.
  *
- * @deprecated Will be removed in oelib 3.0.0. Use ReadOnly (without the "Trait" suffix) instead.
+ * @deprecated Will be removed in oelib 3.0. Use ReadOnly (without the "Trait" suffix) instead.
  *
  * @author Oliver Klee <typo3-coding@oliverklee.de
  */

--- a/Classes/Domain/Repository/Traits/StoragePageAgnosticTrait.php
+++ b/Classes/Domain/Repository/Traits/StoragePageAgnosticTrait.php
@@ -6,7 +6,7 @@ use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
 /**
  * This trait for repositories makes the repository ignore the storage page setting when fetching models.
  *
- * @deprecated Will be removed in oelib 3.0.0. Use StoragePageAgnostic (without the "Trait" suffix) instead.
+ * @deprecated Will be removed in oelib 3.0. Use StoragePageAgnostic (without the "Trait" suffix) instead.
  *
  * @author Oliver Klee <typo3-coding@oliverklee.de
  */


### PR DESCRIPTION
On TYPO3 8.7, extensions might still call this method.