### PR TITLE
[TASK] Stop building with the lowest Composer dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 
 install:
 - >
-  composer require typo3/minimal:"$TYPO3" $SYMFONY_CONSOLE $DEPENDENCIES_PREFERENCE;
+  composer require typo3/minimal:"$TYPO3";
   composer show;
 - >
   .Build/vendor/bin/typo3cms install:setup --non-interactive --site-setup-type="site"
@@ -71,14 +71,8 @@ jobs:
     php: "7.1"
     env: TYPO3=^7.6 RUN_TESTS_COMMAND=".Build/public/typo3/cli_dispatch.phpsh phpunit"
   - stage: test
-    php: "7.1"
-    env: TYPO3=^7.6 DEPENDENCIES_PREFERENCE="--prefer-lowest" RUN_TESTS_COMMAND=".Build/public/typo3/cli_dispatch.phpsh phpunit"
-  - stage: test
     php: "7.0"
     env: TYPO3=^7.6 RUN_TESTS_COMMAND=".Build/public/typo3/cli_dispatch.phpsh phpunit"
-  - stage: test
-    php: "7.0"
-    env: TYPO3=^7.6 DEPENDENCIES_PREFERENCE="--prefer-lowest" RUN_TESTS_COMMAND=".Build/public/typo3/cli_dispatch.phpsh phpunit"
   - stage: release to ter
     if: tag IS present AND env(TYPO3_ORG_USERNAME) IS present AND env(TYPO3_ORG_PASSWORD) IS present
     php: "7.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Mark Db::getDatabaseConnection for removal in version 4.0, not 3.0 (#228)
 
 ### Removed
+- Stop building with the lowest Composer dependencies (#244)
 - Stop providing the DB query in the exceptions (#231)
 - Drop the TYPO3 package repository from composer.json (#227)
 


### PR DESCRIPTION
This has been too much of a hassle due to breakage caused by old
dev dependencies.