### PR TITLE
[TASK] Stop using the phpunit extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,6 @@ script:
   composer ci:tests:unit;
 - >
   echo;
-  echo "Running the legacy unit tests";
-  composer ci:tests:unit-legacy;
-- >
-  echo;
   echo "Running the functional tests";
   composer ci:tests:functional;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Display the name of the current functional test (#293)
 
 ### Changed
-- Convert more tests to nimut/testing-framework (#283, #288, #290, #291, #292, #300, #301, #303)
+- Convert more tests to nimut/testing-framework (#283, #288, #290, #291, #292, #300, #301, #303, #304)
 - Update the testing libraries (#275, #279)
 - Mark tests that do not contain any assertions (#277)
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
 
         "helhum/typo3-console": "^4.9.6",
 
-        "oliverklee/phpunit": "^6.5.14",
         "nimut/testing-framework": "^4.1.8",
         "phpunit/phpunit": "^6.5.14",
         "mikey179/vfsstream": "^1.6.7"
@@ -83,11 +82,9 @@
     "scripts": {
         "ci:php:lint": "find *.php Classes/ Configuration/ TestExtensions/ Tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
         "ci:tests:unit": "phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit/",
-        "ci:tests:unit-legacy": ".Build/vendor/bin/typo3 phpunit:run Tests/LegacyUnit/",
         "ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml {}';",
         "ci:tests": [
             "@ci:tests:unit",
-            "@ci:tests:unit-legacy",
             "@ci:tests:functional"
         ],
         "ci:dynamic": [


### PR DESCRIPTION
Now that all tests are migrated to `nimut/testing-framework`, we
do not need the `oelib` extension for the tests anymore.