### PR TITLE
[BUGFIX] Internally store boolean properties as integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Internally store boolean properties as integers (#360)
 
 ## 3.0.1
 

--- a/Classes/Object.php
+++ b/Classes/Object.php
@@ -212,7 +212,7 @@ abstract class Tx_Oelib_Object
     {
         $this->checkForNonEmptyKey($key);
 
-        $this->set($key, (bool)$value);
+        $this->set($key, (int)(bool)$value);
     }
 
     /**


### PR DESCRIPTION
This avoids problems when persisting models with the ConnectionPool.