### PR TITLE
[BUGFIX] Always provide the table when getting the last insert ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Always provide the table when getting the last insert ID (#361)
 - Internally store boolean properties as integers (#360)
 
 ## 3.0.1

--- a/Classes/Db.php
+++ b/Classes/Db.php
@@ -255,7 +255,7 @@ class Tx_Oelib_Db
 
         if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 9000000) {
             self::getConnectionForTable($tableName)->insert($tableName, self::normalizeDatabaseRow($recordData));
-            $uid = (int)self::getConnectionForTable($tableName)->lastInsertId();
+            $uid = (int)self::getConnectionForTable($tableName)->lastInsertId($tableName);
         } else {
             $connection = self::getDatabaseConnection();
             $dbResult = $connection->exec_INSERTquery($tableName, $recordData);


### PR DESCRIPTION
This avoids hazards when scripts run in parallel.