### PR TITLE
[BUGFIX] Do not cache vendor/ on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
 
 cache:
   directories:
-  - .Build/vendor
   - $HOME/.composer/cache
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Do not cache `vendor/` on Travis CI (#380)
 - Fix warnings in the `travis.yml` (#373)
 - Improve the code autoformatting (#370)
 


### PR DESCRIPTION
This messes up the dependencies too often. Caching the Composer cache
should be enough.