### PR TITLE
[BUGFIX] Do not build with PHP 7.4 for TYPO3 8.7 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,6 @@ jobs:
     php: "7.4"
     env: TYPO3=^9.5
   - stage: test
-    php: "7.4"
-    env: TYPO3=^8.7
-  - stage: test
     php: "7.3"
     env: TYPO3=^9.5
   - stage: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Do not build with PHP 7.4 for TYPO3 8.7 on Travis CI (#381)
 - Do not cache `vendor/` on Travis CI (#380)
 - Fix warnings in the `travis.yml` (#373)
 - Improve the code autoformatting (#370)


### PR DESCRIPTION
This combination currently does not work well yet.