### PR TITLE
[FEATURE] Add a TYPO3 version comparison class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add a TYPO3 version comparison class (#385)
 - Support PHP 7.4 (#376)
 - Support PHP 7.3 (#369)
 

--- a/Classes/Db.php
+++ b/Classes/Db.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Oelib\System\Typo3Version;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\DatabaseConnection;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
@@ -253,7 +253,7 @@ class Tx_Oelib_Db
             throw new \InvalidArgumentException('$recordData must not be empty.', 1331488230);
         }
 
-        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 9000000) {
+        if (Typo3Version::isAtLeast(9)) {
             self::getConnectionForTable($tableName)->insert($tableName, self::normalizeDatabaseRow($recordData));
             $uid = (int)self::getConnectionForTable($tableName)->lastInsertId($tableName);
         } else {

--- a/Classes/FrontEndLoginManager.php
+++ b/Classes/FrontEndLoginManager.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Oelib\System\Typo3Version;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
@@ -71,7 +71,7 @@ class Tx_Oelib_FrontEndLoginManager implements \Tx_Oelib_Interface_LoginManager
     public function isLoggedIn(): bool
     {
         $isSimulatedLoggedIn = $this->loggedInUser instanceof \Tx_Oelib_Model_FrontEndUser;
-        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 9004000) {
+        if (Typo3Version::isNotHigherThan(8)) {
             $controller = $this->getFrontEndController();
             $sessionExists = $controller instanceof TypoScriptFrontendController && $controller->loginUser;
         } else {
@@ -103,7 +103,7 @@ class Tx_Oelib_FrontEndLoginManager implements \Tx_Oelib_Interface_LoginManager
             return null;
         }
 
-        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 9004000) {
+        if (Typo3Version::isNotHigherThan(8)) {
             $uid = (int)$this->getFrontEndController()->fe_user->user['uid'];
         } else {
             $uid = (int)$this->getContext()->getPropertyFromAspect('frontend.user', 'id');

--- a/Classes/SalutationSwitcher.php
+++ b/Classes/SalutationSwitcher.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+use OliverKlee\Oelib\System\Typo3Version;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Plugin\AbstractPlugin;
 use TYPO3\CMS\Lang\LanguageService;
@@ -44,7 +44,7 @@ abstract class Tx_Oelib_SalutationSwitcher extends AbstractPlugin
     public function __sleep()
     {
         $fieldsToSave = \get_object_vars($this);
-        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 9000000) {
+        if (Typo3Version::isNotHigherThan(8)) {
             unset($fieldsToSave['frontendController'], $fieldsToSave['databaseConnection']);
         } else {
             unset($fieldsToSave['frontendController']);
@@ -60,7 +60,7 @@ abstract class Tx_Oelib_SalutationSwitcher extends AbstractPlugin
      */
     public function __wakeup()
     {
-        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 9000000) {
+        if (Typo3Version::isNotHigherThan(8)) {
             $this->databaseConnection = $GLOBALS['TYPO3_DB'];
         }
         $this->frontendController = $this->getFrontEndController();

--- a/Classes/System/Typo3Version.php
+++ b/Classes/System/Typo3Version.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Oelib\System;
+
+/**
+ * Utility class for checking the current TYPO3 version.
+ *
+ * @author Oliver Klee <typo3-coding@oliverklee.de>
+ */
+final class Typo3Version
+{
+    /**
+     * @var \TYPO3\CMS\Core\Information\Typo3Version|null
+     */
+    private static $version = null;
+
+    /**
+     * @return \TYPO3\CMS\Core\Information\Typo3Version
+     *
+     * @throws \BadMethodCallException
+     */
+    private static function getVersionUtility(): \TYPO3\CMS\Core\Information\Typo3Version
+    {
+        if (!\class_exists(\TYPO3\CMS\Core\Information\Typo3Version::class)) {
+            throw new \BadMethodCallException(
+                'The class ' . \TYPO3\CMS\Core\Information\Typo3Version::class . ' does not exist.',
+                1585310637
+            );
+        }
+
+        if (!self::$version instanceof \TYPO3\CMS\Core\Information\Typo3Version) {
+            self::$version = new \TYPO3\CMS\Core\Information\Typo3Version();
+        }
+
+        return self::$version;
+    }
+
+    private static function getMajorVersion(): int
+    {
+        if (\class_exists(\TYPO3\CMS\Core\Information\Typo3Version::class)) {
+            $majorVersion = self::getVersionUtility()->getMajorVersion();
+        } else {
+            $explodedVersion = \explode('.', TYPO3_version);
+            $majorVersion = (int)$explodedVersion[0];
+        }
+
+        return $majorVersion;
+    }
+
+    /**
+     * Checks whether the currently running TYPO3 version is at least the given version.
+     *
+     * @param int $version the version to check against, e.g., 9 for TYPO3 9.7
+     *
+     * @return bool
+     */
+    public static function isAtLeast(int $version): bool
+    {
+        return self::getMajorVersion() >= $version;
+    }
+
+    /**
+     * Checks whether the currently running TYPO3 version is not higher than the given version.
+     *
+     * @param int $version the version to check against, e.g., 9 for TYPO3 9.7
+     *
+     * @return bool
+     */
+    public static function isNotHigherThan(int $version): bool
+    {
+        return self::getMajorVersion() <= $version;
+    }
+}

--- a/Classes/TestingFramework.php
+++ b/Classes/TestingFramework.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use OliverKlee\Oelib\System\Typo3Version;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
@@ -10,7 +11,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\RootlineUtility;
-use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -1355,7 +1355,7 @@ final class Tx_Oelib_TestingFramework
         $frontEnd->fe_user->createUserSession(['uid' => $userId, 'disableIPlock' => true]);
         $frontEnd->fe_user->user = $dataToSet;
         $frontEnd->fe_user->fetchGroupData();
-        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 9004000) {
+        if (Typo3Version::isNotHigherThan(8)) {
             $this->getFrontEndController()->loginUser = true;
         }
     }
@@ -1383,7 +1383,7 @@ final class Tx_Oelib_TestingFramework
 
         $this->suppressFrontEndCookies();
         $this->getFrontEndController()->fe_user->logoff();
-        if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 9004000) {
+        if (Typo3Version::isNotHigherThan(8)) {
             $this->getFrontEndController()->loginUser = false;
         }
 

--- a/Tests/Unit/System/Typo3VersionTest.php
+++ b/Tests/Unit/System/Typo3VersionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Oelib\Tests\Unit\System;
+
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use OliverKlee\Oelib\System\Typo3Version;
+
+/**
+ * Test case.
+ *
+ * @author Oliver Klee <typo3-coding@oliverklee.de>
+ */
+final class Typo3VersionTest extends UnitTestCase
+{
+    /**
+     * @var \TYPO3\CMS\Core\Information\Typo3Version|null
+     */
+    private $version = null;
+
+    protected function setUp()
+    {
+        if (\class_exists(\TYPO3\CMS\Core\Information\Typo3Version::class)) {
+            $this->version = new \TYPO3\CMS\Core\Information\Typo3Version();
+        }
+    }
+
+    private function getMajorVersion(): int
+    {
+        if ($this->version instanceof \TYPO3\CMS\Core\Information\Typo3Version) {
+            $majorVersion = $this->version->getMajorVersion();
+        } else {
+            $explodedVersion = \explode('.', TYPO3_version);
+            $majorVersion = (int)$explodedVersion[0];
+        }
+
+        return $majorVersion;
+    }
+
+    /**
+     * @test
+     */
+    public function isAtLeastForLowerVersionThanCurrentVersionReturnsTrue()
+    {
+        $result = Typo3Version::isAtLeast($this->getMajorVersion() - 1);
+
+        self::assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isAtLeastForCurrentVersionReturnsTrue()
+    {
+        $result = Typo3Version::isAtLeast($this->getMajorVersion());
+
+        self::assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isAtLeastForHigherVersionThanCurrentVersionReturnsFalse()
+    {
+        $result = Typo3Version::isAtLeast($this->getMajorVersion() + 1);
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isNotHigherThanForLowerVersionThanCurrentVersionReturnsFalse()
+    {
+        $result = Typo3Version::isNotHigherThan($this->getMajorVersion() - 1);
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isNotHigherThanForCurrentVersionReturnsTrue()
+    {
+        $result = Typo3Version::isNotHigherThan($this->getMajorVersion());
+
+        self::assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isNotHigherThanForHigherVersionThanCurrentVersionReturnsTrue()
+    {
+        $result = Typo3Version::isNotHigherThan($this->getMajorVersion() + 1);
+
+        self::assertTrue($result);
+    }
+}


### PR DESCRIPTION
This allows version checks in TYPO3 8.7, 9.5 and 10.x.