### PR TITLE
[BUGFIX] Always use Composer-installed versions of the dev tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Always use Composer-installed versions of the dev tools (#388)
 - Do not build with PHP 7.4 for TYPO3 8.7 on Travis CI (#381)
 - Do not cache `vendor/` on Travis CI (#380)
 - Fix warnings in the `travis.yml` (#373, #383)

--- a/composer.json
+++ b/composer.json
@@ -82,12 +82,12 @@
         "vendor-dir": ".Build/vendor"
     },
     "scripts": {
-        "php:fix": "php-cs-fixer --config=Configuration/php-cs-fixer.php fix Classes Tests && phpcbf Classes Configuration Tests TestExtensions",
+        "php:fix": ".Build/vendor/bin/php-cs-fixer --config=Configuration/php-cs-fixer.php fix Classes Tests && .Build/vendor/bin/phpcbf Classes Configuration Tests TestExtensions",
         "ci:php:lint": "find *.php Classes Configuration TestExtensions Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-        "ci:php:sniff": "phpcs Classes Configuration Tests TestExtensions",
-        "ci:php:fixer": "php-cs-fixer --config=Configuration/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff-format=udiff Classes Tests",
-        "ci:tests:unit": "phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit/",
-        "ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml {}';",
+        "ci:php:sniff": ".Build/vendor/bin/phpcs Classes Configuration Tests TestExtensions",
+        "ci:php:fixer": ".Build/vendor/bin/php-cs-fixer --config=Configuration/php-cs-fixer.php fix --dry-run -v --show-progress=dots --diff-format=udiff Classes Tests",
+        "ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit/",
+        "ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml {}';",
         "ci:tests": [
             "@ci:tests:unit",
             "@ci:tests:functional"


### PR DESCRIPTION
This avoids system-installed versions of the same tools
from getting called instead (which might be a different version and
also might not use our Composer autoloader).