### PR TITLE
[BUGFIX] Add .0 version suffixes to PHP version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Add `.0` version suffixes to PHP version requirements (#393)
 - Allow non-string marker contents in templates (#390, #391)
 - Fix crash if no HTML template path is provided (#389)
 - Always use Composer-installed versions of the dev tools (#388)

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "issues": "https://github.com/oliverklee/ext-oelib/issues"
     },
     "require": {
-        "php": "~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4",
+        "php": "~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",


### PR DESCRIPTION
Allowing PHP `~7.4` would allow PHP 7.5 as well (even if that version
most probably will not exist), while `~7.4.0` will not due to the way
the `~` operator for Composer version requirements works.