### PR TITLE
[TASK] Drop TemplateHelper::setCachedConfigurationValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop `TemplateHelper::setCachedConfigurationValue` (#489)
 
 ### Fixed
 - Fix Composer cache keys in the CI configuration file (#433)

--- a/Classes/TemplateHelper.php
+++ b/Classes/TemplateHelper.php
@@ -447,30 +447,6 @@ class Tx_Oelib_TemplateHelper extends SalutationSwitcher
     }
 
     /**
-     * Sets a cached configuration value that will be used when a new instance
-     * is created.
-     *
-     * This function is intended to be used for testing purposes only.
-     *
-     * @param string $key
-     *        key of the configuration property to set, must not be empty
-     * @param mixed $value
-     *        value of the configuration property, may be empty or zero
-     *
-     * @return void
-     */
-    public static function setCachedConfigurationValue(string $key, $value)
-    {
-        $pageUid = PageFinder::getInstance()->getPageUid();
-
-        if (!isset(self::$cachedConfigurations[$pageUid])) {
-            self::$cachedConfigurations[$pageUid] = [];
-        }
-
-        self::$cachedConfigurations[$pageUid][$key] = $value;
-    }
-
-    /**
      * Purges all cached configuration values.
      *
      * This function is intended to be used for testing purposes only.

--- a/Tests/Unit/Templating/TemplateHelperTest.php
+++ b/Tests/Unit/Templating/TemplateHelperTest.php
@@ -68,6 +68,7 @@ class TemplateHelperTest extends UnitTestCase
     {
         GeneralUtility::purgeInstances();
         ConfigurationProxy::purgeInstances();
+        \Tx_Oelib_TemplateHelper::purgeCachedConfigurations();
         parent::tearDown();
     }
 
@@ -205,36 +206,6 @@ class TemplateHelperTest extends UnitTestCase
     ////////////////////////////////////////////////////////
     // Tests for setting and reading configuration values.
     ////////////////////////////////////////////////////////
-
-    /**
-     * @test
-     */
-    public function setCachedConfigurationValueCreatesConfigurationForNewInstance()
-    {
-        \Tx_Oelib_TemplateHelper::setCachedConfigurationValue('foo', 'bar');
-
-        $subject = new \Tx_Oelib_TemplateHelper();
-        $subject->init();
-
-        self::assertSame(
-            'bar',
-            $subject->getConfValueString('foo')
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function purgeCachedConfigurationsDropsCachedConfiguration()
-    {
-        \Tx_Oelib_TemplateHelper::setCachedConfigurationValue('foo', 'bar');
-        \Tx_Oelib_TemplateHelper::purgeCachedConfigurations();
-
-        $subject = new \Tx_Oelib_TemplateHelper();
-        $subject->init([]);
-
-        self::assertSame('', $subject->getConfValueString('foo'));
-    }
 
     /**
      * @test


### PR DESCRIPTION
This method was only used for testing itself, has no other use, and also
the tests using it did not make sense.