### PR TITLE
[BUGFIX] More followup to namespacing all classes

### DIFF
--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -31,7 +31,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  * @author Saskia Metzler <saskia@merlin.owl.de>
  * @author Niels Pardon <mail@niels-pardon.de>
  */
-final class TestingFramework
+class TestingFramework
 {
     /**
      * @var int

--- a/Migrations/Code/ClassAliasMap.php
+++ b/Migrations/Code/ClassAliasMap.php
@@ -37,7 +37,7 @@ return [
     'Tx_Oelib_Exception_NotFound' => \OliverKlee\Oelib\Exception\NotFoundException::class,
 
     // Frontend
-    'Tx_Oelib_FrontEnd_UserWithoutCookies' => \OliverKlee\Oelib\Frontend\UserWithoutCookies::class,
+    'Tx_Oelib_FrontEnd_UserWithoutCookies' => \OliverKlee\Oelib\FrontEnd\UserWithoutCookies::class,
 
     // Geocoding
     'Tx_Oelib_Geocoding_Calculcator' => \OliverKlee\Oelib\Geocoding\GeoCalculator::class,

--- a/Migrations/Code/LegacyClassesForIde.php
+++ b/Migrations/Code/LegacyClassesForIde.php
@@ -227,7 +227,7 @@ namespace {
     /**
      * @deprecated will be removed in oelib 4.0.0
      */
-    class Tx_Oelib_FrontEnd_UserWithoutCookies extends \OliverKlee\Oelib\Frontend\UserWithoutCookies
+    class Tx_Oelib_FrontEnd_UserWithoutCookies extends \OliverKlee\Oelib\FrontEnd\UserWithoutCookies
     {
 
     }


### PR DESCRIPTION
Also fix the used namespace in the migrations.

Also make the testing framework class non-final as long as we have
the legacy class for IDEs inhering from it.