### PR TITLE
[BUGFIX] Use correct cache keys in TYPO3 10LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop `TemplateHelper::setCachedConfigurationValue` (#489)
 
 ### Fixed
+- Use correct cache keys in TYPO3 10LTS (#504)
 - Add necessary int casts (#502)
 - Fix Composer cache keys in the CI configuration file (#433)
 

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -224,12 +224,13 @@ class TestingFramework
             $this->uploadFolderPath = Environment::getPublicPath() . '/typo3temp/' . $this->tablePrefix . '/';
         }
 
+        $cacheKey = $this->getCacheKeyPrefix() . 'rootline';
         /** @var array $rootLineCacheConfiguration */
         $rootLineCacheConfiguration =
-            (array)$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['cache_rootline'];
+            (array)$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$cacheKey];
         $rootLineCacheConfiguration['backend'] = NullBackend::class;
         $rootLineCacheConfiguration['options'] = [];
-        $cacheConfigurations = ['cache_rootline' => $rootLineCacheConfiguration];
+        $cacheConfigurations = [$cacheKey => $rootLineCacheConfiguration];
         /** @var CacheManager $cacheManager */
         $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
         $cacheManager->setCacheConfigurations($cacheConfigurations);
@@ -2085,16 +2086,22 @@ class TestingFramework
      */
     private function registerNullPageCache()
     {
+        $cacheKey = $this->getCacheKeyPrefix() . 'pages';
         /** @var CacheManager $cacheManager */
         $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
-        if ($cacheManager->hasCache('cache_pages')) {
+        if ($cacheManager->hasCache($cacheKey)) {
             return;
         }
 
         /** @var NullBackend $backEnd */
         $backEnd = GeneralUtility::makeInstance(NullBackend::class, 'Testing');
         /** @var VariableFrontend $frontEnd */
-        $frontEnd = GeneralUtility::makeInstance(VariableFrontend::class, 'cache_pages', $backEnd);
+        $frontEnd = GeneralUtility::makeInstance(VariableFrontend::class, $cacheKey, $backEnd);
         $cacheManager->registerCache($frontEnd);
+    }
+
+    private function getCacheKeyPrefix(): string
+    {
+        return Typo3Version::isAtLeast(10) ? '' : '_cache';
     }
 }


### PR DESCRIPTION
Cache keys in TYPO3 10LTS do not have the `cache_` prefix anymore.

Fixes #499