### PR TITLE
[BUGFIX] Always pass a FE controller instance to AbstractPlugin constructor

### DIFF
--- a/Tests/Unit/Language/Fixtures/TestingSalutationSwitcher.php
+++ b/Tests/Unit/Language/Fixtures/TestingSalutationSwitcher.php
@@ -28,8 +28,6 @@ final class TestingSalutationSwitcher extends SalutationSwitcher
      */
     public function __construct(array $configuration)
     {
-        parent::__construct();
-
         $this->conf = $configuration;
 
         $this->pi_setPiVarDefaults();


### PR DESCRIPTION
This fixes the `TemplateHelper` in TYPO3 10LTS.

Fixes #498