### PR TITLE
[CLEANUP] Harden null checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Sort the entries in the `.gitignore` and `.gitattributes` (#368)
 
 ### Fixed
+- Harden null checks (#524)
 - Add `.0` version suffixes to PHP version requirements (#393)
 - Allow non-string marker contents in templates (#390, #391)
 - Fix crash if no HTML template path is provided (#389)

--- a/Classes/Configuration/ConfigurationCheck.php
+++ b/Classes/Configuration/ConfigurationCheck.php
@@ -325,7 +325,7 @@ class ConfigurationCheck
         );
 
         if (
-            ($this->getFrontEndController() !== null)
+            ($this->getFrontEndController() instanceof TypoScriptFrontendController)
             && $this->objectToCheck->hasConfValueString('templateFile', 's_template_special')
         ) {
             $rawFileName = $this->objectToCheck->getConfValueString(

--- a/Classes/Configuration/ConfigurationRegistry.php
+++ b/Classes/Configuration/ConfigurationRegistry.php
@@ -237,8 +237,8 @@ class ConfigurationRegistry
     private function existsFrontEnd(): bool
     {
         $frontEndController = $this->getFrontEndController();
-        return ($frontEndController !== null) && is_object($frontEndController->tmpl)
-            && $frontEndController->tmpl->loaded;
+        return $frontEndController instanceof TypoScriptFrontendController
+            && $frontEndController->tmpl instanceof TemplateService && $frontEndController->tmpl->loaded;
     }
 
     /**

--- a/Classes/Configuration/PageFinder.php
+++ b/Classes/Configuration/PageFinder.php
@@ -177,7 +177,9 @@ class PageFinder
      */
     private function hasFrontEnd(): bool
     {
-        return ($this->getFrontEndController() !== null) && ($this->getFrontEndController()->id > 0);
+        $frontEndController = $this->getFrontEndController();
+
+        return $frontEndController instanceof TypoScriptFrontendController && $frontEndController->id > 0;
     }
 
     /**

--- a/Classes/Database/DatabaseService.php
+++ b/Classes/Database/DatabaseService.php
@@ -27,7 +27,7 @@ class DatabaseService
     /**
      * page object which we will use to call enableFields on
      *
-     * @var PageRepository
+     * @var PageRepository|null
      */
     private static $pageForEnableFields = null;
 
@@ -108,12 +108,15 @@ class DatabaseService
      */
     private static function retrievePageForEnableFields()
     {
-        if (!is_object(self::$pageForEnableFields)) {
-            if ((self::getFrontEndController() !== null) && is_object(self::getFrontEndController()->sys_page)) {
-                self::$pageForEnableFields = self::getFrontEndController()->sys_page;
-            } else {
-                self::$pageForEnableFields = GeneralUtility::makeInstance(PageRepository::class);
-            }
+        if (self::$pageForEnableFields instanceof PageRepository) {
+            return;
+        }
+
+        $controller = self::getFrontEndController();
+        if ($controller instanceof TypoScriptFrontendController && $controller->sys_page instanceof PageRepository) {
+            self::$pageForEnableFields = $controller->sys_page;
+        } else {
+            self::$pageForEnableFields = GeneralUtility::makeInstance(PageRepository::class);
         }
     }
 

--- a/Classes/Email/Mail.php
+++ b/Classes/Email/Mail.php
@@ -133,7 +133,7 @@ class Mail extends AbstractObjectWithAccessors
      */
     public function hasReplyTo(): bool
     {
-        return $this->replyTo !== null;
+        return $this->replyTo instanceof MailRole;
     }
 
     /**

--- a/Classes/Email/MailerFactory.php
+++ b/Classes/Email/MailerFactory.php
@@ -34,7 +34,7 @@ class MailerFactory implements SingletonInterface
      */
     public function cleanUp()
     {
-        if ($this->mailer !== null) {
+        if ($this->mailer instanceof AbstractMailer) {
             $this->mailer->cleanUp();
         }
     }

--- a/Classes/Geocoding/GoogleGeocoding.php
+++ b/Classes/Geocoding/GoogleGeocoding.php
@@ -72,7 +72,7 @@ class GoogleGeocoding implements GeocodingLookup
      */
     public static function getInstance(): GeocodingLookup
     {
-        if (self::$instance === null) {
+        if (!self::$instance instanceof GeocodingLookup) {
             self::$instance = new GoogleGeocoding();
         }
 

--- a/Classes/Mapper/AbstractDataMapper.php
+++ b/Classes/Mapper/AbstractDataMapper.php
@@ -913,7 +913,7 @@ abstract class AbstractDataMapper
      */
     protected function prepareDataForNewRecord(array &$data)
     {
-        if ($this->testingFramework === null) {
+        if (!$this->testingFramework instanceof TestingFramework) {
             return;
         }
 
@@ -1107,7 +1107,7 @@ abstract class AbstractDataMapper
     ): array {
         $recordData = ['uid_local' => $uidLocal, 'uid_foreign' => $uidForeign, 'sorting' => $sorting];
 
-        if ($this->testingFramework !== null) {
+        if ($this->testingFramework instanceof TestingFramework) {
             $this->testingFramework->markTableAsDirty($mnTable);
             $dummyColumnName = $this->testingFramework->getDummyColumnName($mnTable);
             $recordData[$dummyColumnName] = 1;
@@ -1233,7 +1233,7 @@ abstract class AbstractDataMapper
     protected function getUniversalWhereClause(bool $allowHiddenRecords = false): string
     {
         $tableName = $this->getTableName();
-        if ($this->testingFramework !== null) {
+        if ($this->testingFramework instanceof TestingFramework) {
             $dummyColumnName = $this->testingFramework->getDummyColumnName($tableName);
             $leftPart = DatabaseService ::tableHasColumn($this->getTableName(), $dummyColumnName)
                 ? $dummyColumnName . ' = 1' : '1 = 1';
@@ -1625,7 +1625,7 @@ abstract class AbstractDataMapper
         $query = $this->getQueryBuilder();
         $query->select('*')->from($this->getTableName());
         $query->andWhere($query->expr()->eq($relationKey, $query->createNamedParameter($model->getUid())));
-        if ($ignoreList !== null && $ignoreList->getUids() !== '') {
+        if ($ignoreList instanceof Collection && $ignoreList->getUids() !== '') {
             $query->andWhere($query->expr()->notIn('uid', GeneralUtility::intExplode(',', $ignoreList->getUids())));
         }
 

--- a/Classes/Model/FrontEndUser.php
+++ b/Classes/Model/FrontEndUser.php
@@ -712,7 +712,7 @@ class FrontEndUser extends AbstractModel implements MailRole, Address
      */
     public function setCountry(Country $country = null)
     {
-        $countryCode = ($country !== null) ? $country->getIsoAlpha3Code() : '';
+        $countryCode = $country instanceof Country ? $country->getIsoAlpha3Code() : '';
 
         $this->setAsString('static_info_country', $countryCode);
     }
@@ -724,7 +724,7 @@ class FrontEndUser extends AbstractModel implements MailRole, Address
      */
     public function hasCountry(): bool
     {
-        return $this->getCountry() !== null;
+        return $this->getCountry() instanceof Country;
     }
 
     /**

--- a/Classes/Session/Session.php
+++ b/Classes/Session/Session.php
@@ -54,7 +54,7 @@ class Session extends AbstractObjectWithPublicAccessors
      */
     protected function __construct(int $type)
     {
-        if ($this->getFrontEndController() === null) {
+        if (!$this->getFrontEndController() instanceof TypoScriptFrontendController) {
             throw new \BadMethodCallException(
                 'This class must not be instantiated when there is no front end.',
                 1331489053

--- a/Classes/Templating/Template.php
+++ b/Classes/Templating/Template.php
@@ -700,7 +700,7 @@ class Template
      */
     public function getSubpartWithLabels(string $subpartKey = ''): string
     {
-        if ($this->translator === null) {
+        if (!$this->translator instanceof Translator) {
             throw new \BadMethodCallException('Please inject the translator before calling this method.', 1440106254);
         }
 

--- a/Classes/ViewHelpers/PriceViewHelper.php
+++ b/Classes/ViewHelpers/PriceViewHelper.php
@@ -84,7 +84,7 @@ class PriceViewHelper extends AbstractViewHelper
     public function render(): string
     {
         $currency = $this->currency;
-        if ($currency === null) {
+        if (!$currency instanceof Currency) {
             return \number_format($this->value, 2, '.', '');
         }
 


### PR DESCRIPTION
Whenever possible, use explicit `instanceof` calls instead.

This avoids false positives and helps static code analysis.