### PR TITLE
[BUGFIX] Restore TemplateHelper::setCachedConfigurationValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   for more information.
 
 ### Removed
-- Drop `TemplateHelper::setCachedConfigurationValue` (#489)
 
 ### Fixed
+- Restore `TemplateHelper::setCachedConfigurationValue` (#527)
 - Fix the seconds per year constant (#520)
 - Harden `unserialize` calls of extension configuration (#510)
 - Stop using things that are deprecated in TYPO3 V9 (#484, #491, #506, #507, #508)

--- a/Classes/Templating/TemplateHelper.php
+++ b/Classes/Templating/TemplateHelper.php
@@ -470,6 +470,26 @@ class TemplateHelper extends SalutationSwitcher
     }
 
     /**
+     * Sets a cached configuration value that will be used when a new instance is created.
+     *
+     * This function is intended to be used for testing purposes only.
+     *
+     * @param string $key key of the configuration property to set, must not be empty
+     * @param mixed $value value of the configuration property, may be empty or zero
+     *
+     * @return void
+     */
+    public static function setCachedConfigurationValue(string $key, $value)
+    {
+        $pageUid = PageFinder::getInstance()->getPageUid();
+        if (!isset(self::$cachedConfigurations[$pageUid])) {
+            self::$cachedConfigurations[$pageUid] = [];
+        }
+
+        self::$cachedConfigurations[$pageUid][$key] = $value;
+    }
+
+    /**
      * Purges all cached configuration values.
      *
      * This function is intended to be used for testing purposes only.

--- a/Tests/Unit/Templating/TemplateHelperTest.php
+++ b/Tests/Unit/Templating/TemplateHelperTest.php
@@ -211,6 +211,36 @@ class TemplateHelperTest extends UnitTestCase
     /**
      * @test
      */
+    public function setCachedConfigurationValueCreatesConfigurationForNewInstance()
+    {
+        TemplateHelper::setCachedConfigurationValue('foo', 'bar');
+
+        $subject = new TemplateHelper();
+        $subject->init();
+
+        self::assertSame(
+            'bar',
+            $subject->getConfValueString('foo')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function purgeCachedConfigurationsDropsCachedConfiguration()
+    {
+        TemplateHelper::setCachedConfigurationValue('foo', 'bar');
+        TemplateHelper::purgeCachedConfigurations();
+
+        $subject = new TemplateHelper();
+        $subject->init([]);
+
+        self::assertSame('', $subject->getConfValueString('foo'));
+    }
+
+    /**
+     * @test
+     */
     public function configurationInitiallyIsAnEmptyArray()
     {
         self::assertSame(


### PR DESCRIPTION
This method is still used in the seminars tests.

This reverts commit da1d37035099b66aeda1a31afa9aa20dbe8a8c4e.

Fixes #526