### PR TITLE
[BUGFIX] Remove a breaking parameter type declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Remove a breaking parameter type declaration (#531)
 - Restore `TemplateHelper::setCachedConfigurationValue` (#527)
 - Fix the seconds per year constant (#520)
 - Harden `unserialize` calls of extension configuration (#510)

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -44,7 +44,7 @@ class Configuration extends AbstractObjectWithPublicAccessors
      *
      * @return void
      */
-    public function set(string $key, $value)
+    public function set($key, $value)
     {
         if ($key === '') {
             throw new \InvalidArgumentException('$key must not be empty.', 1331318809);

--- a/Classes/Configuration/ConfigurationProxy.php
+++ b/Classes/Configuration/ConfigurationProxy.php
@@ -173,7 +173,7 @@ class ConfigurationProxy extends AbstractObjectWithPublicAccessors
      *
      * @return void
      */
-    protected function set(string $key, $value)
+    protected function set($key, $value)
     {
         $this->loadConfigurationLazily();
 

--- a/Classes/DataStructures/AbstractObjectWithAccessors.php
+++ b/Classes/DataStructures/AbstractObjectWithAccessors.php
@@ -32,7 +32,7 @@ abstract class AbstractObjectWithAccessors
      *
      * @return void
      */
-    abstract protected function set(string $key, $value);
+    abstract protected function set($key, $value);
 
     /**
      * Checks that $key is not empty.

--- a/Classes/Email/Mail.php
+++ b/Classes/Email/Mail.php
@@ -61,7 +61,7 @@ class Mail extends AbstractObjectWithAccessors
      *
      * @return void
      */
-    protected function set(string $key, $value)
+    protected function set($key, $value)
     {
         $this->data[$key] = $value;
     }

--- a/Classes/Model/AbstractModel.php
+++ b/Classes/Model/AbstractModel.php
@@ -257,7 +257,7 @@ abstract class AbstractModel extends AbstractObjectWithAccessors implements Iden
      *
      * @return void
      */
-    protected function set(string $key, $value)
+    protected function set($key, $value)
     {
         if ($key === 'deleted') {
             throw new \InvalidArgumentException(

--- a/Classes/Session/FakeSession.php
+++ b/Classes/Session/FakeSession.php
@@ -52,7 +52,7 @@ class FakeSession extends Session
      *
      * @return void
      */
-    protected function set(string $key, $value)
+    protected function set($key, $value)
     {
         $this->sessionData[$key] = $value;
     }

--- a/Classes/Session/Session.php
+++ b/Classes/Session/Session.php
@@ -151,7 +151,7 @@ class Session extends AbstractObjectWithPublicAccessors
      *
      * @return void
      */
-    protected function set(string $key, $value)
+    protected function set($key, $value)
     {
         $this->getFrontEndController()->fe_user->setKey(self::$types[$this->type], $key, $value);
         $this->getFrontEndController()->fe_user->storeSessionData();

--- a/Tests/Unit/DataStructures/Fixtures/TestingObject.php
+++ b/Tests/Unit/DataStructures/Fixtures/TestingObject.php
@@ -54,7 +54,7 @@ class TestingObject extends AbstractObjectWithPublicAccessors
      *
      * @return void
      */
-    protected function set(string $key, $value)
+    protected function set($key, $value)
     {
         $this->data[$key] = $value;
     }

--- a/Tests/Unit/Email/Fixtures/TestingMailRole.php
+++ b/Tests/Unit/Email/Fixtures/TestingMailRole.php
@@ -41,7 +41,7 @@ class TestingMailRole extends AbstractObjectWithAccessors implements MailRole
      *
      * @return void
      */
-    protected function set(string $key, $value)
+    protected function set($key, $value)
     {
         $this->data[$key] = $value;
     }


### PR DESCRIPTION
The `string` parameter type declaration in `AbstractObjectWithAccessors::set`
breaks the realty extension.

We'll add the type declaration for oelib 4.0.