### PR TITLE
[TASK] Deprecate the UppercaseViewHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 ### Deprecated
+- Deprecate the UppercaseViewHelper (#548)
 
 ### Removed
 

--- a/Classes/ViewHelpers/UppercaseViewHelper.php
+++ b/Classes/ViewHelpers/UppercaseViewHelper.php
@@ -9,6 +9,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 /**
  * This view helper converts strings to uppercase.
  *
+ * @deprecated will be remove in oelib 4.0 - use the `format.case` Fluid view helper instead
+ *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 class UppercaseViewHelper extends AbstractViewHelper


### PR DESCRIPTION
There is a `format.case` view helper in Fluid, and we should not duplicate
that functionality.