### PR TITLE
[TASK] Always build all CI matrix branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       - name: "Run command"
         run: "composer ci:${{ matrix.command }}"
     strategy:
+      fail-fast: false
       matrix:
         command:
           - "php:sniff"
@@ -98,6 +99,7 @@ jobs:
       - name: "Run unit tests"
         run: "composer ci:tests:unit"
     strategy:
+      fail-fast: false
       matrix:
         include:
           - typo3-version: ^8.7
@@ -154,6 +156,7 @@ jobs:
           export typo3DatabasePassword="root";
           composer ci:tests:functional
     strategy:
+      fail-fast: false
       matrix:
         include:
           - typo3-version: ^8.7


### PR DESCRIPTION
This allows us to see which PHP or TYPO3 versions we have broken with
a change.

Fixes #543