### PR TITLE
[TASK] Don't deprecate EmailRole, GeneralEmailRole, SystemEmailFromBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 ### Deprecated
-- Deprecate the UppercaseViewHelper (#548)
+- Don't deprecate `EmailRole`, `GeneralEmailRole`, `SystemEmailFromBuilder` (#551)
+- Deprecate the `UppercaseViewHelper` (#548)
 
 ### Removed
 

--- a/Classes/Email/GeneralEmailRole.php
+++ b/Classes/Email/GeneralEmailRole.php
@@ -9,8 +9,6 @@ use OliverKlee\Oelib\Interfaces\MailRole;
 /**
  * A general email subject.
  *
- * @deprecated will be removed in oelib 4.0
- *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 class GeneralEmailRole implements MailRole

--- a/Classes/Email/SystemEmailFromBuilder.php
+++ b/Classes/Email/SystemEmailFromBuilder.php
@@ -10,8 +10,6 @@ use TYPO3\CMS\Core\Utility\MailUtility;
 /**
  * This class builds email subjects with the email data from the install tool.
  *
- * @deprecated will be removed in oelib 4.0
- *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 class SystemEmailFromBuilder
@@ -41,8 +39,6 @@ class SystemEmailFromBuilder
      * @return GeneralEmailRole
      *
      * @throws \UnexpectedValueException
-     *
-     * @deprecated will be removed in oelib 4.0
      */
     public function build(): GeneralEmailRole
     {

--- a/Classes/Interfaces/MailRole.php
+++ b/Classes/Interfaces/MailRole.php
@@ -7,8 +7,6 @@ namespace OliverKlee\Oelib\Interfaces;
 /**
  * This interfaces represents an e-mail role, e.g. a sender or a recipient.
  *
- * @deprecated will be removed in oelib 4.0
- *
  * @author Niels Pardon <mail@niels-pardon.de>
  */
 interface MailRole


### PR DESCRIPTION
These classes and the interface might still be useful, and they are not
affected by the coming switch from SwiftMailer to Symfony Mailer.

Fixes #542