### PR TITLE
[FEATURE] Add AbstractModel::getAsCollection() as alias for ::getAsList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
+- Add `AbstractModel::getAsCollection()` as an alias for `::getAsList` (#552)
 - Document how to run the tests (#544)
 
 ### Changed
 
 ### Deprecated
+- Deprecate `AbstractModel::getAsList()` (#552)
 - Don't deprecate `EmailRole`, `GeneralEmailRole`, `SystemEmailFromBuilder` (#551)
 - Deprecate the `UppercaseViewHelper` (#548)
 

--- a/Classes/Model/AbstractModel.php
+++ b/Classes/Model/AbstractModel.php
@@ -359,29 +359,45 @@ abstract class AbstractModel extends AbstractObjectWithAccessors implements Iden
     }
 
     /**
-     * Gets the value stored in under the key $key as a list of models.
-     *
-     * @throws \UnexpectedValueException
-     *         if there is a data item stored for the key $key that is not a list instance or if that item has not been
-     *     set yet
+     * Gets the value stored in under the key $key as a collection of models.
      *
      * @param string $key the key of the element to retrieve, must not be empty
      *
      * @return Collection<AbstractModel> the data item for the given key
+     *
+     * @throws \UnexpectedValueException if there is a data item stored for the key $key that is not a collection
+     *         or if that item has not been set yet
      */
-    public function getAsList(string $key): Collection
+    public function getAsCollection(string $key): Collection
     {
         $this->checkForNonEmptyKey($key);
 
         $result = $this->get($key);
         if (!$result instanceof Collection) {
             throw new \UnexpectedValueException(
-                'The data item for the key "' . $key . '" is no list instance.',
+                'The data item for the key "' . $key . '" is no collection.',
                 1331489379
             );
         }
 
         return $result;
+    }
+
+    /**
+     * Gets the value stored in under the key $key as a collection of models.
+     *
+     * @deprecated will be removed in oelib 5.0 - use `getAsCollection` instead
+     *
+     * @param string $key the key of the element to retrieve, must not be empty
+     *
+     * @return Collection<AbstractModel> the data item for the given key
+     *
+     * @throws \UnexpectedValueException if there is a data item stored for the key $key that is not a collection
+     *         or if that item has not been set yet
+     */
+    public function getAsList(string $key): Collection
+    {
+        return $this->getAsCollection($key);
     }
 
     /**

--- a/Tests/Unit/Model/AbstractModelTest.php
+++ b/Tests/Unit/Model/AbstractModelTest.php
@@ -485,21 +485,65 @@ class AbstractModelTest extends UnitTestCase
         );
     }
 
-    ////////////////////////////////
-    // Tests concerning getAsList
-    ////////////////////////////////
+    /*
+     * Tests concerning getAsCollection and getAsList
+     */
+
+    /**
+     * @test
+     */
+    public function getAsCollectionWithEmptyKeyThrowsException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$key must not be empty.');
+
+        $this->subject->getAsCollection('');
+    }
+
+    /**
+     * @test
+     */
+    public function getAsCollectionWithInexistentKeyThrowsException()
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The data item for the key "foo" is no collection.');
+
+        $this->subject->setData([]);
+
+        $this->subject->getAsCollection('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function getAsCollectionWithKeyForStringDataThrowsException()
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The data item for the key "foo" is no collection.');
+
+        $this->subject->setData(['foo' => 'bar']);
+
+        $this->subject->getAsCollection('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function getAsCollectionReturnsCollectionSetViaSetData()
+    {
+        $list = new Collection();
+        $this->subject->setData(['foo' => $list]);
+
+        self::assertSame($list, $this->subject->getAsCollection('foo'));
+    }
 
     /**
      * @test
      */
     public function getAsListWithEmptyKeyThrowsException()
     {
-        $this->expectException(
-            \InvalidArgumentException::class
-        );
-        $this->expectExceptionMessage(
-            '$key must not be empty.'
-        );
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$key must not be empty.');
 
         $this->subject->getAsList('');
     }
@@ -509,18 +553,12 @@ class AbstractModelTest extends UnitTestCase
      */
     public function getAsListWithInexistentKeyThrowsException()
     {
-        $this->expectException(
-            \UnexpectedValueException::class
-        );
-        $this->expectExceptionMessage(
-            'The data item for the key "foo" is no list instance.'
-        );
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The data item for the key "foo" is no collection.');
 
         $this->subject->setData([]);
 
-        self::assertNull(
-            $this->subject->getAsList('foo')
-        );
+        $this->subject->getAsList('foo');
     }
 
     /**
@@ -528,12 +566,8 @@ class AbstractModelTest extends UnitTestCase
      */
     public function getAsListWithKeyForStringDataThrowsException()
     {
-        $this->expectException(
-            \UnexpectedValueException::class
-        );
-        $this->expectExceptionMessage(
-            'The data item for the key "foo" is no list instance.'
-        );
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The data item for the key "foo" is no collection.');
 
         $this->subject->setData(['foo' => 'bar']);
 
@@ -543,17 +577,12 @@ class AbstractModelTest extends UnitTestCase
     /**
      * @test
      */
-    public function getAsListReturnsListSetViaSetData()
+    public function getAsListReturnsCollectionSetViaSetData()
     {
         $list = new Collection();
-        $this->subject->setData(
-            ['foo' => $list]
-        );
+        $this->subject->setData(['foo' => $list]);
 
-        self::assertSame(
-            $list,
-            $this->subject->getAsList('foo')
-        );
+        self::assertSame($list, $this->subject->getAsList('foo'));
     }
 
     /////////////////////////////


### PR DESCRIPTION
Also deprecate `::getAsList`.

Fixes #533