### PR TITLE
[TASK] Rename the Configuration class to TypoScriptConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Document how to run the tests (#544)
 
 ### Changed
+- Rename the Configuration class to TypoScriptConfiguration (#557)
 - Adopt the `.editorconfig` settings from the TYPO3 Core (#555)
 
 ### Deprecated

--- a/Classes/Configuration/ConfigurationRegistry.php
+++ b/Classes/Configuration/ConfigurationRegistry.php
@@ -26,7 +26,7 @@ class ConfigurationRegistry
     private static $instance = null;
 
     /**
-     * @var array<string, Configuration> already created configurations (by namespace)
+     * @var array<string, TypoScriptConfiguration> already created configurations (by namespace)
      */
     private $configurations = [];
 
@@ -78,31 +78,31 @@ class ConfigurationRegistry
     }
 
     /**
-     * Retrieves a Configuration by namespace.
+     * Retrieves a TypoScriptConfiguration by namespace.
      *
      * @param string $namespace
      *        the name of a configuration namespace, e.g., "plugin.tx_oelib",
      *        must not be empty
      *
-     * @return Configuration the configuration for the given namespace
+     * @return TypoScriptConfiguration the configuration for the given namespace
      *
      * @see getByNamespace
      */
-    public static function get(string $namespace): Configuration
+    public static function get(string $namespace): TypoScriptConfiguration
     {
         return self::getInstance()->getByNamespace($namespace);
     }
 
     /**
-     * Retrieves a Configuration by namespace.
+     * Retrieves a TypoScriptConfiguration by namespace.
      *
      * @param string $namespace
      *        the name of a configuration namespace, e.g., "plugin.tx_oelib",
      *        must not be empty
      *
-     * @return Configuration the configuration for the given namespace
+     * @return TypoScriptConfiguration the configuration for the given namespace
      */
-    private function getByNamespace(string $namespace): Configuration
+    private function getByNamespace(string $namespace): TypoScriptConfiguration
     {
         $this->checkForNonEmptyNamespace($namespace);
 
@@ -119,12 +119,12 @@ class ConfigurationRegistry
      *
      * @param string $namespace
      *        the namespace of the configuration to set, must not be empty
-     * @param Configuration $configuration
+     * @param TypoScriptConfiguration $configuration
      *        the configuration to set
      *
      * @return void
      */
-    public function set(string $namespace, Configuration $configuration)
+    public function set(string $namespace, TypoScriptConfiguration $configuration)
     {
         $this->checkForNonEmptyNamespace($namespace);
 
@@ -159,9 +159,9 @@ class ConfigurationRegistry
      * @param string $namespace
      *        the namespace of the configuration to retrieve, must not be empty
      *
-     * @return Configuration the TypoScript configuration for that namespace, might be empty
+     * @return TypoScriptConfiguration the TypoScript configuration for that namespace, might be empty
      */
-    private function retrieveConfigurationFromTypoScriptSetup(string $namespace): Configuration
+    private function retrieveConfigurationFromTypoScriptSetup(string $namespace): TypoScriptConfiguration
     {
         $data = $this->getCompleteTypoScriptSetup();
 
@@ -174,8 +174,8 @@ class ConfigurationRegistry
             $data = $data[$namespacePart . '.'];
         }
 
-        /** @var Configuration $configuration */
-        $configuration = GeneralUtility::makeInstance(Configuration::class);
+        /** @var TypoScriptConfiguration $configuration */
+        $configuration = GeneralUtility::makeInstance(TypoScriptConfiguration::class);
         $configuration->setData($data);
         return $configuration;
     }

--- a/Classes/Configuration/TypoScriptConfiguration.php
+++ b/Classes/Configuration/TypoScriptConfiguration.php
@@ -12,7 +12,7 @@ use OliverKlee\Oelib\DataStructures\AbstractObjectWithPublicAccessors;
  *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
-class Configuration extends AbstractObjectWithPublicAccessors
+class TypoScriptConfiguration extends AbstractObjectWithPublicAccessors
 {
     /**
      * @var array the data for this configuration

--- a/Classes/Language/TranslatorRegistry.php
+++ b/Classes/Language/TranslatorRegistry.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace OliverKlee\Oelib\Language;
 
 use OliverKlee\Oelib\Authentication\BackEndLoginManager;
-use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Configuration\TypoScriptConfiguration;
 use TYPO3\CMS\Core\Localization\LocalizationFactory;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -83,11 +83,11 @@ class TranslatorRegistry
      * The language key is read from the "language" key and the alternate language is read
      * from the language_alt key.
      *
-     * @param Configuration $configuration the configuration to read
+     * @param TypoScriptConfiguration $configuration the configuration to read
      *
      * @return void
      */
-    private function setLanguageKeyFromConfiguration(Configuration $configuration)
+    private function setLanguageKeyFromConfiguration(TypoScriptConfiguration $configuration)
     {
         if (!$configuration->hasString('language')) {
             return;

--- a/Migrations/Code/ClassAliasMap.php
+++ b/Migrations/Code/ClassAliasMap.php
@@ -9,10 +9,11 @@ return [
 
     // Configuration
     'Tx_Oelib_ConfigCheck' => \OliverKlee\Oelib\Configuration\ConfigurationCheck::class,
-    'Tx_Oelib_Configuration' => \OliverKlee\Oelib\Configuration\Configuration::class,
+    'Tx_Oelib_Configuration' => \OliverKlee\Oelib\Configuration\TypoScriptConfiguration::class,
     'Tx_Oelib_ConfigurationProxy' => \OliverKlee\Oelib\Configuration\ConfigurationProxy::class,
     'Tx_Oelib_ConfigurationRegistry' => \OliverKlee\Oelib\Configuration\ConfigurationRegistry::class,
     'Tx_Oelib_PageFinder' => \OliverKlee\Oelib\Configuration\PageFinder::class,
+    \OliverKlee\Oelib\Configuration\Configuration::class => \OliverKlee\Oelib\Configuration\TypoScriptConfiguration::class,
 
     // Database
     'Tx_Oelib_Db' => \OliverKlee\Oelib\Database\DatabaseService::class,

--- a/Migrations/Code/LegacyClassesForIde.php
+++ b/Migrations/Code/LegacyClassesForIde.php
@@ -42,7 +42,7 @@ namespace {
     /**
      * @deprecated will be removed in oelib 4.0.0
      */
-    class Tx_Oelib_Configuration extends \OliverKlee\Oelib\Configuration\Configuration
+    class Tx_Oelib_Configuration extends \OliverKlee\Oelib\Configuration\TypoScriptConfiguration
     {
 
     }
@@ -759,6 +759,16 @@ namespace {
      * @deprecated will be removed in oelib 4.0.0
      */
     class Tx_Oelib_Visibility_Tree extends \OliverKlee\Oelib\Visibility\Tree
+    {
+
+    }
+}
+
+namespace OliverKlee\Oelib\Configuration {
+    /**
+     * @deprecated will be removed in oelib 5.0.0
+     */
+    class Configuration extends \OliverKlee\Oelib\Configuration\TypoScriptConfiguration
     {
 
     }

--- a/Tests/Functional/Configuration/ConfigurationRegistryTest.php
+++ b/Tests/Functional/Configuration/ConfigurationRegistryTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace OliverKlee\Oelib\Tests\Functional\Configuration;
 
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
-use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\PageFinder;
+use OliverKlee\Oelib\Configuration\TypoScriptConfiguration;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -54,7 +54,7 @@ class ConfigurationRegistryTest extends FunctionalTestCase
         );
 
         self::assertInstanceOf(
-            Configuration::class,
+            TypoScriptConfiguration::class,
             ConfigurationRegistry::get('plugin.tx_oelib')
         );
     }
@@ -187,7 +187,7 @@ class ConfigurationRegistryTest extends FunctionalTestCase
         );
         PageFinder::getInstance()->setPageUid($pageUid);
 
-        $configuration = new Configuration();
+        $configuration = new TypoScriptConfiguration();
         ConfigurationRegistry::getInstance()
             ->set('plugin.tx_oelib', $configuration);
 

--- a/Tests/Functional/Language/TranslatorRegistryTest.php
+++ b/Tests/Functional/Language/TranslatorRegistryTest.php
@@ -6,8 +6,8 @@ namespace OliverKlee\Oelib\Tests\Functional\Language;
 
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use OliverKlee\Oelib\Authentication\BackEndLoginManager;
-use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Configuration\TypoScriptConfiguration;
 use OliverKlee\Oelib\Language\Translator;
 use OliverKlee\Oelib\Language\TranslatorRegistry;
 use OliverKlee\Oelib\Model\BackEndUser;
@@ -33,12 +33,12 @@ class TranslatorRegistryTest extends FunctionalTestCase
         parent::setUp();
 
         $configurationRegistry = ConfigurationRegistry::getInstance();
-        $configurationRegistry->set('config', new Configuration());
-        $configurationRegistry->set('page.config', new Configuration());
-        $configurationRegistry->set('plugin.tx_oelib._LOCAL_LANG', new Configuration());
-        $configurationRegistry->set('plugin.tx_oelib._LOCAL_LANG.default', new Configuration());
-        $configurationRegistry->set('plugin.tx_oelib._LOCAL_LANG.de', new Configuration());
-        $configurationRegistry->set('plugin.tx_oelib._LOCAL_LANG.fr', new Configuration());
+        $configurationRegistry->set('config', new TypoScriptConfiguration());
+        $configurationRegistry->set('page.config', new TypoScriptConfiguration());
+        $configurationRegistry->set('plugin.tx_oelib._LOCAL_LANG', new TypoScriptConfiguration());
+        $configurationRegistry->set('plugin.tx_oelib._LOCAL_LANG.default', new TypoScriptConfiguration());
+        $configurationRegistry->set('plugin.tx_oelib._LOCAL_LANG.de', new TypoScriptConfiguration());
+        $configurationRegistry->set('plugin.tx_oelib._LOCAL_LANG.fr', new TypoScriptConfiguration());
     }
 
     private function setUpFrontEnd()

--- a/Tests/Unit/Configuration/ConfigurationRegistryTest.php
+++ b/Tests/Unit/Configuration/ConfigurationRegistryTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace OliverKlee\Oelib\Tests\Unit\Configuration;
 
 use Nimut\TestingFramework\TestCase\UnitTestCase;
-use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Configuration\TypoScriptConfiguration;
 
 /**
  * Test case.
@@ -88,7 +88,7 @@ class ConfigurationRegistryTest extends UnitTestCase
 
         ConfigurationRegistry::getInstance()->set(
             '',
-            new Configuration()
+            new TypoScriptConfiguration()
         );
     }
 
@@ -97,7 +97,7 @@ class ConfigurationRegistryTest extends UnitTestCase
      */
     public function getAfterSetReturnsTheSetInstance()
     {
-        $configuration = new Configuration();
+        $configuration = new TypoScriptConfiguration();
 
         ConfigurationRegistry::getInstance()
             ->set('foo', $configuration);
@@ -117,11 +117,11 @@ class ConfigurationRegistryTest extends UnitTestCase
     {
         ConfigurationRegistry::getInstance()->set(
             'foo',
-            new Configuration()
+            new TypoScriptConfiguration()
         );
         ConfigurationRegistry::getInstance()->set(
             'foo',
-            new Configuration()
+            new TypoScriptConfiguration()
         );
     }
 }

--- a/Tests/Unit/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/Configuration/TypoScriptConfigurationTest.php
@@ -6,27 +6,36 @@ namespace OliverKlee\Oelib\Tests\Unit\Configuration;
 
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use OliverKlee\Oelib\Configuration\Configuration;
+use OliverKlee\Oelib\Configuration\TypoScriptConfiguration;
 
 /**
  * Test case.
  *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
-class ConfigurationTest extends UnitTestCase
+class TypoScriptConfigurationTest extends UnitTestCase
 {
     /**
-     * @var Configuration
+     * @var TypoScriptConfiguration
      */
     private $subject;
 
     protected function setUp()
     {
-        $this->subject = new Configuration();
+        $this->subject = new TypoScriptConfiguration();
     }
 
     //////////////////////////////////////
     // Tests for the basic functionality
     //////////////////////////////////////
+
+    /**
+     * @test
+     */
+    public function hasAlias()
+    {
+        self::assertInstanceOf(Configuration::class, $this->subject);
+    }
 
     /**
      * @test

--- a/Tests/Unit/Geocoding/GoogleGeocodingTest.php
+++ b/Tests/Unit/Geocoding/GoogleGeocodingTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace OliverKlee\Oelib\Tests\Unit\Geocoding;
 
 use Nimut\TestingFramework\TestCase\UnitTestCase;
-use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Configuration\TypoScriptConfiguration;
 use OliverKlee\Oelib\Geocoding\DummyGeocodingLookup;
 use OliverKlee\Oelib\Geocoding\GoogleGeocoding;
 use OliverKlee\Oelib\Tests\Unit\Geocoding\Fixtures\TestingGeo;
@@ -25,15 +25,15 @@ class GoogleGeocodingTest extends UnitTestCase
     private $subject = null;
 
     /**
-     * @var Configuration
+     * @var TypoScriptConfiguration
      */
     private $configuration = null;
 
     protected function setUp()
     {
         $configurationRegistry = ConfigurationRegistry::getInstance();
-        $configurationRegistry->set('plugin', new Configuration());
-        $this->configuration = new Configuration();
+        $configurationRegistry->set('plugin', new TypoScriptConfiguration());
+        $this->configuration = new TypoScriptConfiguration();
         $configurationRegistry->set('plugin.tx_oelib', $this->configuration);
 
         $this->subject = GoogleGeocoding::getInstance();

--- a/Tests/Unit/ViewHelpers/GoogleMapsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/GoogleMapsViewHelperTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace OliverKlee\Oelib\Tests\Unit\ViewHelpers;
 
 use Nimut\TestingFramework\TestCase\ViewHelperBaseTestcase;
-use OliverKlee\Oelib\Configuration\Configuration;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
+use OliverKlee\Oelib\Configuration\TypoScriptConfiguration;
 use OliverKlee\Oelib\Interfaces\MapPoint;
 use OliverKlee\Oelib\Tests\Unit\ViewHelpers\Fixtures\TestingMapPoint;
 use OliverKlee\Oelib\ViewHelpers\GoogleMapsViewHelper;
@@ -26,7 +26,7 @@ class GoogleMapsViewHelperTest extends ViewHelperBaseTestcase
     private $subject = null;
 
     /**
-     * @var Configuration
+     * @var TypoScriptConfiguration
      */
     private $configuration = null;
 
@@ -45,8 +45,8 @@ class GoogleMapsViewHelperTest extends ViewHelperBaseTestcase
         parent::setUp();
 
         $configurationRegistry = ConfigurationRegistry::getInstance();
-        $configurationRegistry->set('plugin', new Configuration());
-        $this->configuration = new Configuration();
+        $configurationRegistry->set('plugin', new TypoScriptConfiguration());
+        $this->configuration = new TypoScriptConfiguration();
         $configurationRegistry->set('plugin.tx_oelib', $this->configuration);
 
         $this->mockFrontEnd = $this->createMock(TypoScriptFrontendController::class);


### PR DESCRIPTION
This make the difference to other configuration types more clear.

Fixes #556.