### PR TITLE
[TASK] Make the FlexformsConfiguration read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add a base class for objects with read-only data (#578)
 - Add a `DummyConfiguration` class (#567)
 - Add a `Configuration` interface (#565, #568)
-- Add a `FlexformsConfiguration` class (#564)
+- Add a `FlexformsConfiguration` class (#564, #579)
 - Add a `DynamicDateViewHelper` (#554)
 - Add `AbstractModel::getAsCollection()` as an alias for `::getAsList` (#552)
 - Document how to run the tests (#544)

--- a/Classes/Configuration/FlexformsConfiguration.php
+++ b/Classes/Configuration/FlexformsConfiguration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Oelib\Configuration;
 
-use OliverKlee\Oelib\DataStructures\AbstractObjectWithPublicAccessors;
+use OliverKlee\Oelib\DataStructures\AbstractReadOnlyObjectWithPublicAccessors;
 use OliverKlee\Oelib\Interfaces\Configuration as ConfigurationInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -15,13 +15,8 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
-class FlexformsConfiguration extends AbstractObjectWithPublicAccessors implements ConfigurationInterface
+class FlexformsConfiguration extends AbstractReadOnlyObjectWithPublicAccessors implements ConfigurationInterface
 {
-    /**
-     * @var \DOMDocument|null
-     */
-    private $xmlDocument = null;
-
     /**
      * @var \DOMXPath|null
      */
@@ -46,7 +41,6 @@ class FlexformsConfiguration extends AbstractObjectWithPublicAccessors implement
         $libXmlState = \libxml_use_internal_errors(true);
         $document->loadXML($flexFormsXml);
         if (\libxml_get_errors() === []) {
-            $this->xmlDocument = $document;
             $this->xPath = new \DOMXPath($document);
         }
 
@@ -67,18 +61,5 @@ class FlexformsConfiguration extends AbstractObjectWithPublicAccessors implement
         $firstMatchingNode = $matchingNodes instanceof \DOMNodeList ? $matchingNodes->item(0) : null;
 
         return $firstMatchingNode instanceof \DOMNode ? (string)$firstMatchingNode->textContent : '';
-    }
-
-    /**
-     * Sets nothing as this class is a read-only accessor for Flexforms configuration.
-     *
-     * @param string $key
-     * @param mixed $value
-     *
-     * @throws \BadMethodCallException
-     */
-    protected function set($key, $value)
-    {
-        throw new \BadMethodCallException('This is a read-only configuration. You cannot set any values.', 1612002594);
     }
 }

--- a/Tests/Unit/Configuration/FlexformsConfigurationTest.php
+++ b/Tests/Unit/Configuration/FlexformsConfigurationTest.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Oelib\Tests\Unit\Configuration;
 
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use OliverKlee\Oelib\Configuration\FlexformsConfiguration;
+use OliverKlee\Oelib\DataStructures\AbstractReadOnlyObjectWithPublicAccessors;
 use OliverKlee\Oelib\Interfaces\Configuration as ConfigurationInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -53,43 +54,11 @@ final class FlexformsConfigurationTest extends UnitTestCase
     /**
      * @test
      */
-    public function setAsStringThrowsException()
+    public function isReadOnlyObjectWithPublicAccessors()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('This is a read-only configuration. You cannot set any values.');
-        $this->expectExceptionCode(1612002594);
-
         $subject = new FlexformsConfiguration(new ContentObjectRenderer());
 
-        $subject->setAsString('flavor', 'hello');
-    }
-
-    /**
-     * @test
-     */
-    public function setAsIntegerThrowsException()
-    {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('This is a read-only configuration. You cannot set any values.');
-        $this->expectExceptionCode(1612002594);
-
-        $subject = new FlexformsConfiguration(new ContentObjectRenderer());
-
-        $subject->setAsInteger('flavor', 1);
-    }
-
-    /**
-     * @test
-     */
-    public function setAsBooleanThrowsException()
-    {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('This is a read-only configuration. You cannot set any values.');
-        $this->expectExceptionCode(1612002594);
-
-        $subject = new FlexformsConfiguration(new ContentObjectRenderer());
-
-        $subject->setAsBoolean('flavor', true);
+        self::assertInstanceOf(AbstractReadOnlyObjectWithPublicAccessors::class, $subject);
     }
 
     /**


### PR DESCRIPTION
There is no need to modify an existing Flexforms configuration
at runtime.

Fixes #563