### PR TITLE
[TASK] Throw an exception for an invalid check method in the tests

### DIFF
--- a/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
@@ -122,9 +122,39 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
     /**
      * @test
      */
+    public function checkWithUnknownCheckMethodThrowsException()
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionCode(1616068312);
+        $this->expectExceptionMessage('Unknown value for the check method: "unknown"');
+
+        $subject = new TestingConfigurationCheck(new DummyConfiguration(), 'plugin.tx_oelib');
+        $subject->setCheckMethod('unknown');
+
+        $subject->check();
+    }
+
+    /**
+     * @test
+     */
+    public function checkWithoutCheckMethodThrowsException()
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionCode(1616068312);
+        $this->expectExceptionMessage('Unknown value for the check method: ""');
+
+        $subject = new TestingConfigurationCheck(new DummyConfiguration(), 'plugin.tx_oelib');
+
+        $subject->check();
+    }
+
+    /**
+     * @test
+     */
     public function checkWithoutCreatingWarningsDoesNotAddAnyWarning()
     {
         $subject = new TestingConfigurationCheck(new DummyConfiguration(), 'plugin.tx_oelib');
+        $subject->setCheckMethod('checkNothing');
 
         $subject->check();
 

--- a/Tests/Unit/Configuration/Fixtures/TestingConfigurationCheck.php
+++ b/Tests/Unit/Configuration/Fixtures/TestingConfigurationCheck.php
@@ -61,6 +61,8 @@ final class TestingConfigurationCheck extends AbstractConfigurationCheck
      * This method does not reset any existing configuration check warnings.
      *
      * @return void
+     *
+     * @throws \BadMethodCallException
      */
     protected function checkAllConfigurationValues()
     {
@@ -89,7 +91,13 @@ final class TestingConfigurationCheck extends AbstractConfigurationCheck
             case 'checkIfInteger':
                 $this->checkIfInteger('limit', 'some explanation');
                 break;
+            case 'checkNothing':
+                break;
             default:
+                throw new \BadMethodCallException(
+                    'Unknown value for the check method: "' . $this->checkMethod . '"',
+                    1616068312
+                );
         }
     }
 }


### PR DESCRIPTION
This should allow us to find errors in the test for the
configuration check faster.