### PR TITLE
[TASK] Rename ConfigurationCheck::checkIfInteger

### DIFF
--- a/Classes/Configuration/AbstractConfigurationCheck.php
+++ b/Classes/Configuration/AbstractConfigurationCheck.php
@@ -273,7 +273,7 @@ abstract class AbstractConfigurationCheck
     /**
      * Checks whether a configuration value has a non-negative integer value (or is empty).
      */
-    protected function checkIfInteger(string $key, string $explanation): bool
+    protected function checkIfNonNegativeIntegerOrEmpty(string $key, string $explanation): bool
     {
         $value = $this->configuration->getAsString($key);
         if ($value === '') {
@@ -300,7 +300,7 @@ abstract class AbstractConfigurationCheck
         if ($minimum > $maximum) {
             throw new \InvalidArgumentException('$minimum must be <= $maximum.', 1616069185);
         }
-        if (!$this->checkIfInteger($key, $explanation)) {
+        if (!$this->checkIfNonNegativeIntegerOrEmpty($key, $explanation)) {
             return false;
         }
 

--- a/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
@@ -413,10 +413,10 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
      *
      * @dataProvider nonIntegerStringDataProvider
      */
-    public function checkIfIntegerForNonIntegerStringAddsWarningWithPathAndExplanation(string $value)
+    public function checkIfNonNegativeIntegerOrEmptyForNonIntegerStringAddsWarningWithPathAndExplanation(string $value)
     {
         $subject = new TestingConfigurationCheck(new DummyConfiguration(['limit' => $value]), 'plugin.tx_oelib');
-        $subject->setCheckMethod('checkIfInteger');
+        $subject->setCheckMethod('checkIfNonNegativeIntegerOrEmpty');
 
         $subject->check();
 
@@ -429,10 +429,10 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
     /**
      * @test
      */
-    public function checkIfIntegerForNegativeIntegerStringAddsWarningWithPathAndExplanation()
+    public function checkIfNonNegativeIntegerOrEmptyForNegativeIntegerStringAddsWarningWithPathAndExplanation()
     {
         $subject = new TestingConfigurationCheck(new DummyConfiguration(['limit' => '-1']), 'plugin.tx_oelib');
-        $subject->setCheckMethod('checkIfInteger');
+        $subject->setCheckMethod('checkIfNonNegativeIntegerOrEmpty');
 
         $subject->check();
 
@@ -459,10 +459,10 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
      *
      * @dataProvider nonNegativeIntegerDataProvider
      */
-    public function checkIfIntegerForNonNegativeIntegerNotAddsWarning(string $value)
+    public function checkIfNonNegativeIntegerOrEmptyForNonNegativeIntegerNotAddsWarning(string $value)
     {
         $subject = new TestingConfigurationCheck(new DummyConfiguration(['limit' => $value]), 'plugin.tx_oelib');
-        $subject->setCheckMethod('checkIfInteger');
+        $subject->setCheckMethod('checkIfNonNegativeIntegerOrEmpty');
 
         $subject->check();
 
@@ -472,10 +472,10 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
     /**
      * @test
      */
-    public function checkIfIntegerEmptyStringNotAddsWarning()
+    public function checkIfNonNegativeIntegerOrEmptyForEmptyStringNotAddsWarning()
     {
         $subject = new TestingConfigurationCheck(new DummyConfiguration(['limit' => '']), 'plugin.tx_oelib');
-        $subject->setCheckMethod('checkIfInteger');
+        $subject->setCheckMethod('checkIfNonNegativeIntegerOrEmpty');
 
         $subject->check();
 

--- a/Tests/Unit/Configuration/Fixtures/TestingConfigurationCheck.php
+++ b/Tests/Unit/Configuration/Fixtures/TestingConfigurationCheck.php
@@ -91,8 +91,8 @@ final class TestingConfigurationCheck extends AbstractConfigurationCheck
             case 'checkIfBoolean':
                 $this->checkIfBoolean('switch', 'some explanation');
                 break;
-            case 'checkIfInteger':
-                $this->checkIfInteger('limit', 'some explanation');
+            case 'checkIfNonNegativeIntegerOrEmpty':
+                $this->checkIfNonNegativeIntegerOrEmpty('limit', 'some explanation');
                 break;
             case 'checkIfIntegerInRange':
                 $this->checkIfIntegerInRange('limit', 2, 4, 'some explanation');


### PR DESCRIPTION
`checkIfNonNegativeIntegerOrEmpty` more precisely describes what the
function does.

Part of #462.