### PR TITLE
[TASK] De-deprecate the HTTP-related classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Update the `.editorconfig` to better match the Core (#614)
 
 ### Deprecated
+- De-deprecate the HTTP-related classes (#616)
 
 ### Removed
 

--- a/Classes/Http/HeaderCollector.php
+++ b/Classes/Http/HeaderCollector.php
@@ -12,8 +12,6 @@ use OliverKlee\Oelib\Http\Interfaces\HeaderProxy;
  *
  * Regarding the Strategy pattern, addHeader() represents one concrete behavior.
  *
- * @deprecated will be removed in oelib 4.0
- *
  * @author Saskia Metzler <saskia@merlin.owl.de>
  */
 class HeaderCollector implements HeaderProxy

--- a/Classes/Http/HeaderProxyFactory.php
+++ b/Classes/Http/HeaderProxyFactory.php
@@ -13,8 +13,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * collector stores the headers that were added and does not send them. This
  * mode is for testing purposes.
  *
- * @deprecated will be removed in oelib 4.0
- *
  * @author Saskia Metzler <saskia@merlin.owl.de>
  */
 class HeaderProxyFactory

--- a/Classes/Http/Interfaces/HeaderProxy.php
+++ b/Classes/Http/Interfaces/HeaderProxy.php
@@ -10,8 +10,6 @@ namespace OliverKlee\Oelib\Http\Interfaces;
  *
  * Regarding the Strategy pattern, addHeader() represents the abstract strategy.
  *
- * @deprecated will be removed in oelib 4.0
- *
  * @author Saskia Metzler <saskia@merlin.owl.de>
  */
 interface HeaderProxy

--- a/Classes/Http/RealHeaderProxy.php
+++ b/Classes/Http/RealHeaderProxy.php
@@ -11,8 +11,6 @@ use OliverKlee\Oelib\Http\Interfaces\HeaderProxy;
  *
  * Regarding the Strategy pattern, addHeader() represents one concrete behavior.
  *
- * @deprecated will be removed in oelib 4.0
- *
  * @author Saskia Metzler <saskia@merlin.owl.de>
  */
 class RealHeaderProxy implements HeaderProxy


### PR DESCRIPTION
We cannot easily replace the calls to these classes in our code yet
as the `HttpUtility` methods are static, and we cannot easily switch
the `AbstractPlugin`-based classes to the new HTTP middleware.

Fixes #615