### PR TITLE
[CLEANUP] Fix all PHPStan level 0 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Add missing call parameter in the `ConfigurationCheck` (#628)
 
 ## 3.3.0
 

--- a/Classes/Configuration/ConfigurationCheck.php
+++ b/Classes/Configuration/ConfigurationCheck.php
@@ -903,7 +903,7 @@ class ConfigurationCheck
 
             foreach ($allValues as $currentValue) {
                 if (!in_array($currentValue, $allowedValues, true)) {
-                    $message = $this->buildWarningStartWithKeyAndValue($key) .
+                    $message = $this->buildWarningStartWithKeyAndValue($key, $currentValue) .
                         'the following values are allowed: <br/><strong>' . $this->buildValueOverview($allowedValues) .
                         '</strong><br />' .
                         $explanation;

--- a/Classes/Database/DatabaseService.php
+++ b/Classes/Database/DatabaseService.php
@@ -615,6 +615,8 @@ class DatabaseService
      * @return DatabaseConnection
      *
      * @deprecated will be removed in oelib 4.0
+     *
+     * @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
      */
     public static function getDatabaseConnection(): DatabaseConnection
     {

--- a/Classes/Language/SalutationSwitcher.php
+++ b/Classes/Language/SalutationSwitcher.php
@@ -61,6 +61,7 @@ abstract class SalutationSwitcher extends AbstractPlugin
     public function __wakeup()
     {
         if (Typo3Version::isNotHigherThan(8)) {
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $this->databaseConnection = $GLOBALS['TYPO3_DB'];
         }
         $this->frontendController = $this->getFrontEndController();

--- a/Tests/Unit/Mapper/MapperRegistryTest.php
+++ b/Tests/Unit/Mapper/MapperRegistryTest.php
@@ -83,6 +83,7 @@ class MapperRegistryTest extends UnitTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
+        // @phpstan-ignore-next-line We're testing a contract violation here on purpose.
         MapperRegistry::get(InexistentMapper::class);
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,22 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Method OliverKlee\\\\Oelib\\\\Configuration\\\\ConfigurationCheck\\:\\:buildWarningStartWithKeyAndValue\\(\\) invoked with 1 parameter, 2 required\\.$#"
-			count: 1
-			path: Classes/Configuration/ConfigurationCheck.php
-
-		-
-			message: "#^Return typehint of method OliverKlee\\\\Oelib\\\\Database\\\\DatabaseService\\:\\:getDatabaseConnection\\(\\) has invalid type TYPO3\\\\CMS\\\\Core\\\\Database\\\\DatabaseConnection\\.$#"
-			count: 1
-			path: Classes/Database/DatabaseService.php
-
-		-
-			message: "#^Access to an undefined property OliverKlee\\\\Oelib\\\\Language\\\\SalutationSwitcher\\:\\:\\$databaseConnection\\.$#"
-			count: 1
-			path: Classes/Language/SalutationSwitcher.php
-
-		-
-			message: "#^Class OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Mapper\\\\InexistentMapper not found\\.$#"
-			count: 1
-			path: Tests/Unit/Mapper/MapperRegistryTest.php
-


### PR DESCRIPTION
In addition to silencing warnings, also add a missing call parameter.