### PR TITLE
[TASK] Drop `type="text/javascript"` from `script` tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - De-deprecate the HTTP-related classes (#616)
 
 ### Removed
+- Drop `type="text/javascript"` from `script` tags (#634)
 
 ### Fixed
 - Stop using the TYPO3-custom whitespace constant (#631)

--- a/Classes/Templating/TemplateHelper.php
+++ b/Classes/Templating/TemplateHelper.php
@@ -1051,12 +1051,7 @@ class TemplateHelper extends SalutationSwitcher
     {
         if ($this->hasConfValueString('jsFile', 's_template_special')) {
             $this->getFrontEndController()->additionalHeaderData[$this->prefixId . '_js']
-                = '<script type="text/javascript" src="'
-                . $this->getConfValueString(
-                    'jsFile',
-                    's_template_special',
-                    true
-                ) . '"></script>';
+                = '<script src="' . $this->getConfValueString('jsFile', 's_template_special', true) . '"></script>';
         }
     }
 

--- a/Classes/ViewHelpers/GoogleMapsViewHelper.php
+++ b/Classes/ViewHelpers/GoogleMapsViewHelper.php
@@ -118,7 +118,7 @@ class GoogleMapsViewHelper extends AbstractViewHelper
         // pageRenderer->addJsLibrary() would not work here if this ViewHelper
         // is used in an uncached plugin on a cached page.
         $this->getFrontEndController()->additionalHeaderData[self::LIBRARY_JAVASCRIPT_HEADER_KEY]
-            = '<script src="' . self::GOOGLE_MAPS_LIBRARY_URL . $apiKey . '" type="text/javascript"></script>';
+            = '<script src="' . self::GOOGLE_MAPS_LIBRARY_URL . $apiKey . '></script>';
 
         $initializeFunctionName = 'initializeGoogleMap_' . $this->mapNumber;
         $this->getFrontEndController()->additionalJavaScript[$mapId]
@@ -128,7 +128,7 @@ class GoogleMapsViewHelper extends AbstractViewHelper
         // for uncached plugins on cached pages.
         return '<div id="' . $mapId . '" style="width: ' .
             $width . '; height: ' . $height . ";\"></div>\n" .
-            '<script type="text/javascript">' . $initializeFunctionName . "();</script>\n";
+            '<script>' . $initializeFunctionName . "();</script>\n";
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/GoogleMapsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/GoogleMapsViewHelperTest.php
@@ -241,10 +241,8 @@ class GoogleMapsViewHelperTest extends ViewHelperBaseTestcase
         $this->subject->render([$this->mapPointWithCoordinates]);
 
         self::assertContains(
-            '<script src="https://maps.googleapis.com/maps/api/js?key=' . $apiKey
-            . '" type="text/javascript"></script>',
-            $this->mockFrontEnd
-                ->additionalHeaderData[GoogleMapsViewHelper::LIBRARY_JAVASCRIPT_HEADER_KEY]
+            '<script src="https://maps.googleapis.com/maps/api/js?key=' . $apiKey . '></script>',
+            $this->mockFrontEnd->additionalHeaderData[GoogleMapsViewHelper::LIBRARY_JAVASCRIPT_HEADER_KEY]
         );
     }
 


### PR DESCRIPTION
This is not needed anymore with modern HTML versions.

Fixes #630