### PR TITLE
[TASK] Deprecate the `ReadOnly` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Update the `.editorconfig` to better match the Core (#614)
 
 ### Deprecated
+- Deprecate the `ReadOnly` trait (#635)
 - De-deprecate the HTTP-related classes (#616)
 
 ### Removed

--- a/Classes/Domain/Repository/GermanZipCodeRepository.php
+++ b/Classes/Domain/Repository/GermanZipCodeRepository.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace OliverKlee\Oelib\Domain\Repository;
 
 use OliverKlee\Oelib\Domain\Model\GermanZipCode;
-use OliverKlee\Oelib\Domain\Repository\Traits\ReadOnly;
+use OliverKlee\Oelib\Domain\Repository\Traits\ReadOnlyRepository;
 use OliverKlee\Oelib\Domain\Repository\Traits\StoragePageAgnostic;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 class GermanZipCodeRepository extends Repository
 {
-    use ReadOnly;
+    use ReadOnlyRepository;
     use StoragePageAgnostic;
 
     /**

--- a/Classes/Domain/Repository/Traits/ReadOnly.php
+++ b/Classes/Domain/Repository/Traits/ReadOnly.php
@@ -6,73 +6,10 @@ namespace OliverKlee\Oelib\Domain\Repository\Traits;
 
 /**
  * This trait marks repositories as read-only.
+ *
+ * @deprecated will be removed in oelib 4.0 (as the trait name breaks compatibility with PHP 8.1)
  */
 trait ReadOnly
 {
-    /**
-     * Adds an object to this repository.
-     *
-     * @param object $object The object to add
-     *
-     * @return void
-     *
-     * @throws \BadMethodCallException
-     */
-    public function add($object)
-    {
-        $this->preventWriteOperation();
-    }
-
-    /**
-     * Removes an object from this repository.
-     *
-     * @param object $object The object to remove
-     *
-     * @return void
-     *
-     * @throws \BadMethodCallException
-     */
-    public function remove($object)
-    {
-        $this->preventWriteOperation();
-    }
-
-    /**
-     * Replaces an existing object with the same identifier by the given object.
-     *
-     * @param object $modifiedObject The modified object
-     *
-     * @return void
-     *
-     * @throws \BadMethodCallException
-     */
-    public function update($modifiedObject)
-    {
-        $this->preventWriteOperation();
-    }
-
-    /**
-     * Removes all objects of this repository as if remove() was called for all of them.
-     *
-     * @return void
-     *
-     * @throws \BadMethodCallException
-     */
-    public function removeAll()
-    {
-        $this->preventWriteOperation();
-    }
-
-    /**
-     * @return void
-     *
-     * @throws \BadMethodCallException
-     */
-    private function preventWriteOperation()
-    {
-        throw new \BadMethodCallException(
-            'This is a read-only repository in which the removeAll method must not be called.',
-            1537544385
-        );
-    }
+    use ReadOnlyRepository;
 }

--- a/Classes/Domain/Repository/Traits/ReadOnlyRepository.php
+++ b/Classes/Domain/Repository/Traits/ReadOnlyRepository.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Oelib\Domain\Repository\Traits;
+
+/**
+ * This trait marks repositories as read-only.
+ */
+trait ReadOnlyRepository
+{
+    /**
+     * Adds an object to this repository.
+     *
+     * @param object $object The object to add
+     *
+     * @return void
+     *
+     * @throws \BadMethodCallException
+     */
+    public function add($object)
+    {
+        $this->preventWriteOperation();
+    }
+
+    /**
+     * Removes an object from this repository.
+     *
+     * @param object $object The object to remove
+     *
+     * @return void
+     *
+     * @throws \BadMethodCallException
+     */
+    public function remove($object)
+    {
+        $this->preventWriteOperation();
+    }
+
+    /**
+     * Replaces an existing object with the same identifier by the given object.
+     *
+     * @param object $modifiedObject The modified object
+     *
+     * @return void
+     *
+     * @throws \BadMethodCallException
+     */
+    public function update($modifiedObject)
+    {
+        $this->preventWriteOperation();
+    }
+
+    /**
+     * Removes all objects of this repository as if remove() was called for all of them.
+     *
+     * @return void
+     *
+     * @throws \BadMethodCallException
+     */
+    public function removeAll()
+    {
+        $this->preventWriteOperation();
+    }
+
+    /**
+     * @return void
+     *
+     * @throws \BadMethodCallException
+     */
+    private function preventWriteOperation()
+    {
+        throw new \BadMethodCallException(
+            'This is a read-only repository in which the removeAll method must not be called.',
+            1537544385
+        );
+    }
+}

--- a/Tests/Unit/Domain/Repository/Fixtures/ReadOnlyRepository.php
+++ b/Tests/Unit/Domain/Repository/Fixtures/ReadOnlyRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Oelib\Tests\Unit\Domain\Repository\Fixtures;
 
-use OliverKlee\Oelib\Domain\Repository\Traits\ReadOnly;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
@@ -12,5 +11,5 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  */
 class ReadOnlyRepository extends Repository
 {
-    use ReadOnly;
+    use \OliverKlee\Oelib\Domain\Repository\Traits\ReadOnlyRepository;
 }


### PR DESCRIPTION
The new Trait now is named `ReadOnlyRepository`.
(The old name breaks compatibility with PHP 8.1.)

Fixes #621