### PR TITLE
[CLEANUP] Silence PHPStan warnings for TYPO3 8LTS

### DIFF
--- a/Classes/Authentication/FrontEndLoginManager.php
+++ b/Classes/Authentication/FrontEndLoginManager.php
@@ -80,6 +80,7 @@ class FrontEndLoginManager implements LoginManager
         $isSimulatedLoggedIn = $this->loggedInUser instanceof FrontEndUser;
         if (Typo3Version::isNotHigherThan(8)) {
             $controller = $this->getFrontEndController();
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $sessionExists = $controller instanceof TypoScriptFrontendController && $controller->loginUser;
         } else {
             $sessionExists = (bool)$this->getContext()->getPropertyFromAspect('frontend.user', 'isLoggedIn');

--- a/Classes/Database/DatabaseService.php
+++ b/Classes/Database/DatabaseService.php
@@ -266,10 +266,12 @@ class DatabaseService
             $uid = (int)self::getConnectionForTable($tableName)->lastInsertId($tableName);
         } else {
             $connection = self::getDatabaseConnection();
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $dbResult = $connection->exec_INSERTquery($tableName, $recordData);
             if ($dbResult === false) {
                 throw new DatabaseException('Database error.', 1573836507);
             }
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $uid = $connection->sql_insert_id();
         }
 
@@ -308,6 +310,7 @@ class DatabaseService
             throw new \InvalidArgumentException('$fields must not be empty.', 1331488270);
         }
 
+        // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
         $dbResult = self::getDatabaseConnection()->exec_SELECTquery(
             $fields,
             $tableNames,

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -1232,7 +1232,9 @@ class TestingFramework
 
         if (Typo3Version::isNotHigherThan(8)) {
             // simulates a normal FE without any logged-in FE or BE user
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $frontEnd->beUserLogin = false;
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $frontEnd->workspacePreview = '';
             $frontEnd->initFEuser();
         } else {
@@ -1394,6 +1396,7 @@ class TestingFramework
         $frontEnd->fe_user->user = $dataToSet;
         $frontEnd->fe_user->fetchGroupData();
         if (Typo3Version::isNotHigherThan(8)) {
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $this->getFrontEndController()->loginUser = true;
         }
     }
@@ -1422,6 +1425,7 @@ class TestingFramework
         $this->suppressFrontEndCookies();
         $this->getFrontEndController()->fe_user->logoff();
         if (Typo3Version::isNotHigherThan(8)) {
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $this->getFrontEndController()->loginUser = false;
         }
 

--- a/Tests/Functional/Configuration/ConfigurationRegistryTest.php
+++ b/Tests/Functional/Configuration/ConfigurationRegistryTest.php
@@ -8,6 +8,7 @@ use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use OliverKlee\Oelib\Configuration\ConfigurationRegistry;
 use OliverKlee\Oelib\Configuration\PageFinder;
 use OliverKlee\Oelib\Configuration\TypoScriptConfiguration;
+use OliverKlee\Oelib\System\Typo3Version;
 use OliverKlee\Oelib\Testing\TestingFramework;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -158,7 +159,10 @@ class ConfigurationRegistryTest extends FunctionalTestCase
         );
         /** @var TypoScriptFrontendController $frontEndController */
         $frontEndController = $GLOBALS['TSFE'];
-        $frontEndController->tmpl->rootId = 0;
+        if (Typo3Version::isNotHigherThan(8)) {
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
+            $frontEndController->tmpl->rootId = 0;
+        }
         $frontEndController->tmpl->rootLine = false;
         $frontEndController->tmpl->setup = [];
         $frontEndController->tmpl->loaded = 0;

--- a/Tests/Functional/Database/DatabaseServiceTest.php
+++ b/Tests/Functional/Database/DatabaseServiceTest.php
@@ -907,6 +907,7 @@ class DatabaseServiceTest extends FunctionalTestCase
         }
 
         DatabaseService ::insert('tx_oelib_test', ['is_dummy_record' => 1]);
+        // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
         $uid = DatabaseService ::getDatabaseConnection()->sql_insert_id();
 
         self::assertSame(

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -3100,6 +3100,7 @@ class TestingFrameworkTest extends FunctionalTestCase
         $this->subject->createFakeFrontEnd();
 
         if (Typo3Version::isNotHigherThan(8)) {
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $isLoggedIn = $this->getFrontEndController()->loginUser;
         } else {
             $isLoggedIn = (bool)$this->getContext()->getPropertyFromAspect('frontend.user', 'isLoggedIn');
@@ -3118,6 +3119,7 @@ class TestingFrameworkTest extends FunctionalTestCase
 
         // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
         if (VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 9004000) {
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $groups = GeneralUtility::intExplode(',', $this->getFrontEndController()->gr_list);
         } else {
             $groups = (array)$this->getContext()->getPropertyFromAspect('frontend.user', 'groupIds');
@@ -3193,6 +3195,7 @@ class TestingFrameworkTest extends FunctionalTestCase
         $this->subject->logoutFrontEndUser();
 
         if (Typo3Version::isNotHigherThan(8)) {
+            // @phpstan-ignore-next-line We run the PHPStan checks with TYPO3 9LTS, and this code is for 8 only.
             $isLoggedIn = $this->getFrontEndController()->loginUser;
         } else {
             $isLoggedIn = (bool)$this->getContext()->getPropertyFromAspect('frontend.user', 'isLoggedIn');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,29 +1,9 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Access to protected property TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\:\\:\\$loginUser\\.$#"
-			count: 1
-			path: Classes/Authentication/FrontEndLoginManager.php
-
-		-
 			message: "#^Constant TYPO3_MODE not found\\.$#"
 			count: 1
 			path: Classes/Configuration/ConfigurationCheck.php
-
-		-
-			message: "#^Call to method exec_INSERTquery\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Database\\\\DatabaseConnection\\.$#"
-			count: 1
-			path: Classes/Database/DatabaseService.php
-
-		-
-			message: "#^Call to method exec_SELECTquery\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Database\\\\DatabaseConnection\\.$#"
-			count: 1
-			path: Classes/Database/DatabaseService.php
-
-		-
-			message: "#^Call to method sql_insert_id\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Database\\\\DatabaseConnection\\.$#"
-			count: 1
-			path: Classes/Database/DatabaseService.php
 
 		-
 			message: "#^Call to an undefined method OliverKlee\\\\Oelib\\\\Interfaces\\\\Configuration\\:\\:getArrayKeys\\(\\)\\.$#"
@@ -86,34 +66,9 @@ parameters:
 			path: Classes/Templating/TemplateHelper.php
 
 		-
-			message: "#^Access to protected property TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\:\\:\\$beUserLogin\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Access to protected property TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\:\\:\\$loginUser\\.$#"
-			count: 2
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Access to protected property TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\:\\:\\$workspacePreview\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
 			message: "#^PHPDoc tag @var has invalid value \\(\\<string, array\\<string, array\\>\\>\\)\\: Unexpected token \"\\<\", expected type at offset 170$#"
 			count: 1
 			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Access to protected property TYPO3\\\\CMS\\\\Core\\\\TypoScript\\\\TemplateService\\:\\:\\$rootId\\.$#"
-			count: 1
-			path: Tests/Functional/Configuration/ConfigurationRegistryTest.php
-
-		-
-			message: "#^Call to method sql_insert_id\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Database\\\\DatabaseConnection\\.$#"
-			count: 1
-			path: Tests/Functional/Database/DatabaseServiceTest.php
 
 		-
 			message: "#^Call to an undefined method OliverKlee\\\\Oelib\\\\Interfaces\\\\Configuration\\:\\:set\\(\\)\\.$#"
@@ -139,16 +94,6 @@ parameters:
 			message: "#^Call to an undefined method OliverKlee\\\\Oelib\\\\Interfaces\\\\Configuration\\:\\:setAsBoolean\\(\\)\\.$#"
 			count: 1
 			path: Tests/Functional/Templating/TemplateHelperTest.php
-
-		-
-			message: "#^Access to protected property TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\:\\:\\$gr_list\\.$#"
-			count: 1
-			path: Tests/Functional/Testing/TestingFrameworkTest.php
-
-		-
-			message: "#^Access to protected property TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\:\\:\\$loginUser\\.$#"
-			count: 2
-			path: Tests/Functional/Testing/TestingFrameworkTest.php
 
 		-
 			message: "#^Call to an undefined method OliverKlee\\\\Oelib\\\\Interfaces\\\\Configuration\\:\\:retrieveConfiguration\\(\\)\\.$#"


### PR DESCRIPTION
PHPStan runs with TYPO3 9LTS and hence does not recognize the 8LTS code.