### PR TITLE
[BUGFIX] Require an extension needed for the tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
 		"oliverklee/user-oelibtest2": "@dev",
 		"phpunit/phpunit": "^6.5.14 || ^7.5.20",
 		"sjbr/static-info-tables": "^6.8.0",
-		"squizlabs/php_codesniffer": "^3.6.0"
+		"squizlabs/php_codesniffer": "^3.6.0",
+		"typo3/cms-extensionmanager": "^8.7 || ^9.5"
 	},
 	"conflict": {
 		"sjbr/static-info-tables": "6.7.1",


### PR DESCRIPTION
The `static_info_tables` extension requires the extension manager,
but does not declare this as a dependency.

Declare this missing dependecy as a dev dependency now in order to
avoid test breakage as a workaround.