### PR TITLE
[BUGFIX] Stop packaging the included Composer packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,7 @@
 /CODE_OF_CONDUCT.md export-ignore
 /Configuration/php-cs-fixer.php export-ignore
 /Resources/Private/Patches/ export-ignore
-/Resources/Private/Php/update.sh export-ignore
+/Resources/Private/Php/ export-ignore
 /TestExtensions/ export-ignore
 /Tests/ export-ignore
 /phpcs.xml.dist export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Stop exporting the included Composer packages for Composer packages (#651)
 - Improve the PHPDoc type annotations (#650)
 - Use `$_EXTKEY` in `ext_emconf.php` again (#649)
 


### PR DESCRIPTION
When this extension is used via Composer, there is no need to package
its own Composer dependencies anymore.

Fixes #647