### PR TITLE
[TASK] Stop making the mapper generics extendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Stop making the mapper generics extendable (#670)
 
 ### Fixed
 

--- a/Classes/Mapper/BackEndUserGroupMapper.php
+++ b/Classes/Mapper/BackEndUserGroupMapper.php
@@ -7,7 +7,6 @@ namespace OliverKlee\Oelib\Mapper;
 use OliverKlee\Oelib\Model\BackEndUserGroup;
 
 /**
- * @template M of BackEndUserGroup
  * @extends AbstractDataMapper<BackEndUserGroup>
  */
 class BackEndUserGroupMapper extends AbstractDataMapper

--- a/Classes/Mapper/BackEndUserMapper.php
+++ b/Classes/Mapper/BackEndUserMapper.php
@@ -10,7 +10,6 @@ use OliverKlee\Oelib\Model\BackEndUser;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
- * @template M of BackEndUser
  * @extends AbstractDataMapper<BackEndUser>
  */
 class BackEndUserMapper extends AbstractDataMapper

--- a/Classes/Mapper/FrontEndUserGroupMapper.php
+++ b/Classes/Mapper/FrontEndUserGroupMapper.php
@@ -7,7 +7,6 @@ namespace OliverKlee\Oelib\Mapper;
 use OliverKlee\Oelib\Model\FrontEndUserGroup;
 
 /**
- * @template M of FrontEndUserGroup
  * @extends AbstractDataMapper<FrontEndUserGroup>
  */
 class FrontEndUserGroupMapper extends AbstractDataMapper

--- a/Classes/Mapper/FrontEndUserMapper.php
+++ b/Classes/Mapper/FrontEndUserMapper.php
@@ -11,7 +11,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * @template M of FrontEndUser
  * @extends AbstractDataMapper<FrontEndUser>
  */
 class FrontEndUserMapper extends AbstractDataMapper


### PR DESCRIPTION
This has proven to not work, and so we should remove it.

This reverts commit 8953ec05e14405ba8286b3927ef9a5eb1817acdc.