### PR TITLE
[TASK] Show allowed configuration values without enclosing quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Display the allowed configuration values without enclosing quotes (#686)
 
 ### Deprecated
 

--- a/Classes/Configuration/AbstractConfigurationCheck.php
+++ b/Classes/Configuration/AbstractConfigurationCheck.php
@@ -33,7 +33,7 @@ abstract class AbstractConfigurationCheck
 
     /**
      * @param ConfigurationInterface $configurationToCheck the configuration to check
-     * @param string $typoScriptNamespace the TypoScript namespace of the configuration, e.g., `plugin.tx_oelib"
+     * @param string $typoScriptNamespace the TypoScript namespace of the configuration, e.g., `plugin.tx_oelib`
      */
     public function __construct(ConfigurationInterface $configurationToCheck, string $typoScriptNamespace)
     {
@@ -65,13 +65,13 @@ abstract class AbstractConfigurationCheck
     }
 
     /**
-     * Builds a HTML-safe, text-only overview of the given values.
+     * Builds an HTML-safe, text-only overview of the given values.
      *
      * @param string[] $values
      */
     protected function buildValueOverview(array $values): string
     {
-        return $this->encode('("' . \implode('", "', $values) . '")');
+        return $this->encode('(' . \implode(', ', $values) . ')');
     }
 
     /**

--- a/Classes/Configuration/ConfigurationCheck.php
+++ b/Classes/Configuration/ConfigurationCheck.php
@@ -18,14 +18,14 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  * structures.
  *
  * Functions for checking a class (optionally with a flavor) must follow the
- * naming schema "check_classname" or "check_classname_flavor"
+ * naming schema `check_classname` or `check_classname_flavor`
  * (if a flavor is used).
  *
- * Example: The check method for objects of the class "tx_seminars_seminarbag"
- * (without any special flavor) must be named "check_tx_seminars_seminarbag".
- * The check method for objects of the class "tx_seminars_pi1" with the flavor
- * "seminar_registration" needs to be named
- * "check_tx_seminars_pi1_seminar_registration".
+ * Example: The check method for objects of the class `tx_seminars_seminarbag`
+ * (without any special flavor) must be named `check_tx_seminars_seminarbag`.
+ * The check method for objects of the class `tx_seminars_pi1` with the flavor
+ * `seminar_registration` needs to be named
+ * `check_tx_seminars_pi1_seminar_registration`.
  *
  * The correct functioning of this class does not rely on any HTML templates or
  * language files so it works even under the worst of circumstances.
@@ -272,7 +272,7 @@ class ConfigurationCheck
 
     /**
      * Wraps $message in (in this case) <p></p>, styled nicely alarming,
-     * with the lang attribute set to "en".
+     * with the lang attribute set to `en`.
      * In addition, the message is prepended by "Configuration check warning: "
      * and followed by "When that is done, please empty the FE cache and
      * reload this page."
@@ -281,7 +281,7 @@ class ConfigurationCheck
      *
      * @param string $message text to be wrapped (may be empty)
      *
-     * @return string $message wrapped in <p></p>
+     * @return string $message wrapped in `<p></p>`
      */
     protected function wrap(string $message): string
     {
@@ -337,13 +337,13 @@ class ConfigurationCheck
     }
 
     /**
-     * Builds a HTML-safe, text-only overview of the given values.
+     * Builds an HTML-safe, text-only overview of the given values.
      *
      * @param string[] $values
      */
     protected function buildValueOverview(array $values): string
     {
-        return $this->encode('("' . \implode('", "', $values) . '")');
+        return $this->encode('(' . \implode(', ', $values) . ')');
     }
 
     /**

--- a/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
@@ -838,7 +838,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertContains('plugin.tx_oelib.sizes', $warning);
         self::assertContains('some explanation', $warning);
-        self::assertContains('(&quot;s&quot;, &quot;m&quot;)', $warning);
+        self::assertContains('(s, m)', $warning);
     }
 
     /**
@@ -855,7 +855,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertContains('plugin.tx_oelib.sizes', $warning);
         self::assertContains('some explanation', $warning);
-        self::assertContains('(&quot;s&quot;, &quot;m&quot;)', $warning);
+        self::assertContains('(s, m)', $warning);
     }
 
     /**
@@ -927,7 +927,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertContains('plugin.tx_oelib.sizes', $warning);
         self::assertContains('some explanation', $warning);
-        self::assertContains('(&quot;s&quot;, &quot;m&quot;)', $warning);
+        self::assertContains('(s, m)', $warning);
     }
 
     /**
@@ -944,7 +944,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertContains('plugin.tx_oelib.sizes', $warning);
         self::assertContains('some explanation', $warning);
-        self::assertContains('(&quot;s&quot;, &quot;m&quot;)', $warning);
+        self::assertContains('(s, m)', $warning);
     }
 
     /**

--- a/Tests/Unit/Configuration/ConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/ConfigurationCheckTest.php
@@ -9,6 +9,9 @@ use OliverKlee\Oelib\Configuration\ConfigurationCheck;
 use OliverKlee\Oelib\Interfaces\ConfigurationCheckable;
 use OliverKlee\Oelib\Tests\Unit\Configuration\Fixtures\DummyObjectToCheck;
 
+/**
+ * @covers \OliverKlee\Oelib\Configuration\ConfigurationCheck
+ */
 class ConfigurationCheckTest extends UnitTestCase
 {
     /**


### PR DESCRIPTION
This makes copy'n'pasting the allowed values a lot easier.

Fixes #684