### PR TITLE
[BUGFIX] Always display the incorrect value in the configuration check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.0 and 7.1 (#690)
 
 ### Fixed
+- Always display the incorrect value in the configuration check (#751)
 - Fix the `TemplateHelper` initialization (#740)
 - Allow `DateTimeImmutable` as change and creation date (#734)
 - Update the usage of the Fluid view helper classes (#732)

--- a/Classes/Configuration/AbstractConfigurationCheck.php
+++ b/Classes/Configuration/AbstractConfigurationCheck.php
@@ -151,14 +151,14 @@ abstract class AbstractConfigurationCheck
      */
     protected function buildWarningStartWithKeyAndValue(string $key, $value): string
     {
-        return $this->buildWarningStartWithKey($key) . 'is set to the value &quot;<strong>' .
+        return $this->buildWarningStartWithKey($key) . 'contains the value &quot;<strong>' .
             $this->encode((string)$value) . '</strong>&quot;, but only ';
     }
 
     /**
      * Retrieves the column names of a given DB table name.
      *
-     * @param string $tableName the name of a existing DB table (must not be empty, must exist)
+     * @param string $tableName the name of an existing DB table (must not be empty, must exist)
      *
      * @return string[] column names as values
      */
@@ -407,9 +407,9 @@ abstract class AbstractConfigurationCheck
 
         $values = GeneralUtility::trimExplode(',', $this->configuration->getAsString($key), true);
 
-        foreach ($values as $currentValue) {
-            if (!\in_array($currentValue, $allowedValues, true)) {
-                $message = $this->buildWarningStartWithKey($key) .
+        foreach ($values as $value) {
+            if (!\in_array($value, $allowedValues, true)) {
+                $message = $this->buildWarningStartWithKeyAndValue($key, $value) .
                     'the following values are allowed: <br/><strong>' . $this->buildValueOverview($allowedValues) .
                     '</strong><br />' .
                     $explanation;

--- a/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
@@ -280,6 +280,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         self::assertTrue($subject->hasWarnings());
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertStringContainsString('plugin.tx_oelib.size', $warning);
+        self::assertStringContainsString('great', $warning);
         self::assertStringContainsString('some explanation', $warning);
     }
 
@@ -325,6 +326,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         self::assertTrue($subject->hasWarnings());
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertStringContainsString('plugin.tx_oelib.size', $warning);
+        self::assertStringContainsString('great', $warning);
         self::assertStringContainsString('some explanation', $warning);
     }
 
@@ -838,6 +840,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertStringContainsString('plugin.tx_oelib.sizes', $warning);
         self::assertStringContainsString('some explanation', $warning);
+        self::assertStringContainsString('great', $warning);
         self::assertStringContainsString('(s, m)', $warning);
     }
 
@@ -927,6 +930,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertStringContainsString('plugin.tx_oelib.sizes', $warning);
         self::assertStringContainsString('some explanation', $warning);
+        self::assertStringContainsString('great', $warning);
         self::assertStringContainsString('(s, m)', $warning);
     }
 


### PR DESCRIPTION
Now the value also is display for "multi in set" contraints.