### PR TITLE
[BUGFIX] Always display the incorrect value in the configuration check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Always display the incorrect value in the configuration check (#754)
 
 ## 3.6.2
 

--- a/Classes/Configuration/AbstractConfigurationCheck.php
+++ b/Classes/Configuration/AbstractConfigurationCheck.php
@@ -162,14 +162,14 @@ abstract class AbstractConfigurationCheck
      */
     protected function buildWarningStartWithKeyAndValue(string $key, $value): string
     {
-        return $this->buildWarningStartWithKey($key) . 'is set to the value &quot;<strong>' .
+        return $this->buildWarningStartWithKey($key) . 'contains the value &quot;<strong>' .
             $this->encode((string)$value) . '</strong>&quot;, but only ';
     }
 
     /**
      * Retrieves the column names of a given DB table name.
      *
-     * @param string $tableName the name of a existing DB table (must not be empty, must exist)
+     * @param string $tableName the name of an existing DB table (must not be empty, must exist)
      *
      * @return string[] column names as values
      */
@@ -418,9 +418,9 @@ abstract class AbstractConfigurationCheck
 
         $values = GeneralUtility::trimExplode(',', $this->configuration->getAsString($key), true);
 
-        foreach ($values as $currentValue) {
-            if (!\in_array($currentValue, $allowedValues, true)) {
-                $message = $this->buildWarningStartWithKey($key) .
+        foreach ($values as $value) {
+            if (!\in_array($value, $allowedValues, true)) {
+                $message = $this->buildWarningStartWithKeyAndValue($key, $value) .
                     'the following values are allowed: <br/><strong>' . $this->buildValueOverview($allowedValues) .
                     '</strong><br />' .
                     $explanation;

--- a/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
@@ -280,6 +280,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         self::assertTrue($subject->hasWarnings());
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertContains('plugin.tx_oelib.size', $warning);
+        self::assertContains('great', $warning);
         self::assertContains('some explanation', $warning);
     }
 
@@ -325,6 +326,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         self::assertTrue($subject->hasWarnings());
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertContains('plugin.tx_oelib.size', $warning);
+        self::assertContains('great', $warning);
         self::assertContains('some explanation', $warning);
     }
 
@@ -838,6 +840,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertContains('plugin.tx_oelib.sizes', $warning);
         self::assertContains('some explanation', $warning);
+        self::assertContains('great', $warning);
         self::assertContains('(s, m)', $warning);
     }
 
@@ -927,6 +930,7 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         $warning = $subject->getWarningsAsHtml()[0];
         self::assertContains('plugin.tx_oelib.sizes', $warning);
         self::assertContains('some explanation', $warning);
+        self::assertContains('great', $warning);
         self::assertContains('(s, m)', $warning);
     }
 


### PR DESCRIPTION
Now the value also is display for "multi in set" constraints.