### PR TITLE
[TASK] Deprecate `ConfigurationCheckable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Improve the styling of the config check warnings (#755)
 
 ### Deprecated
+- Deprecate `ConfigurationCheckable` (#766)
 
 ### Removed
 

--- a/Classes/Interfaces/ConfigurationCheckable.php
+++ b/Classes/Interfaces/ConfigurationCheckable.php
@@ -6,6 +6,8 @@ namespace OliverKlee\Oelib\Interfaces;
 
 /**
  * This interface represents an object that can have an automatic configuration check.
+ *
+ * @deprecated will be removed in oelib 4.0; use `AbstractConfigurationCheck` instead (without any interface)
  */
 interface ConfigurationCheckable
 {


### PR DESCRIPTION
This interface was only needed for the legacy configuration check
(which will be removed in oelib 4.0).

Fixes #765