### PR TITLE
[TASK] Deprecate the setters of `ConfigurationProxy` and `TypoScriptConfiguration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Improve the styling of the config check warnings (#755)
 
 ### Deprecated
+- Deprecate the setters of `ConfigurationProxy` and `TypoScriptConfiguration` (#774)
 - Deprecate `ConfigurationCheckable` (#766)
 
 ### Removed

--- a/Classes/Configuration/ConfigurationProxy.php
+++ b/Classes/Configuration/ConfigurationProxy.php
@@ -179,10 +179,10 @@ class ConfigurationProxy extends AbstractObjectWithPublicAccessors implements Co
      *
      * The configuration setters are intended to be used for testing purposes only.
      *
-     * @param string $key
-     *        key of the value to set, must not be empty
-     * @param mixed $value
-     *        the value to set
+     * @deprecated will be removed in oelib 4.0; use the `DummyConfiguration` in tests instead
+     *
+     * @param string $key key of the value to set, must not be empty
+     * @param mixed $value the value to set
      *
      * @return void
      */

--- a/Classes/Configuration/TypoScriptConfiguration.php
+++ b/Classes/Configuration/TypoScriptConfiguration.php
@@ -35,10 +35,10 @@ class TypoScriptConfiguration extends AbstractObjectWithPublicAccessors implemen
     /**
      * Sets the value of the data item for the key $key.
      *
-     * @param string $key
-     *        the key of the data item to get, must not be empty
-     * @param mixed $value
-     *        the data for the key $key
+     * @deprecated will be removed in oelib 4.0; use the `DummyConfiguration` in tests instead
+     *
+     * @param string $key the key of the data item to get, must not be empty
+     * @param mixed $value the data for the key $key
      *
      * @return void
      */


### PR DESCRIPTION
These configuration classes will be immutable in oelib 4.0.

Instead, the `DummyConfiguration` should be used.