### PR TITLE
[FEATURE] Add a function for disabling some Core caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.0 and 7.1 (#690)
 
 ### Fixed
-- Adapt the tests and testing framework to TYPO3 10LTS (#767, #777, #778, #779)
+- Adapt the tests and testing framework to TYPO3 10LTS (#767, #777, #778, #779, #780)
 - Recognize flexforms data converted to an array (#753)
 - Always display the incorrect value in the configuration check (#751)
 - Fix the `TemplateHelper` initialization (#740)

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -1943,7 +1943,10 @@ final class TestingFramework
         return $cacheManager;
     }
 
-    private function disableCoreCaches(): void
+    /**
+     * Sets the following Core caches to the null backen: l10n, rootline, runtime
+     */
+    public function disableCoreCaches(): void
     {
         $this->getCacheManager()->setCacheConfigurations(
             [

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -7,6 +7,8 @@ namespace OliverKlee\Oelib\Tests\Functional\Testing;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use OliverKlee\Oelib\Authentication\FrontEndLoginManager;
 use OliverKlee\Oelib\Testing\TestingFramework;
+use TYPO3\CMS\Core\Cache\Backend\NullBackend;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
@@ -2812,5 +2814,32 @@ final class TestingFrameworkTest extends FunctionalTestCase
             'user_oelibtest_is_dummy_record',
             $testingFramework->getDummyColumnName('user_oelibtest2_test')
         );
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function cacheDataProvider(): array
+    {
+        return [
+            'l10n' => ['l10n'],
+            'rootline' => ['rootline'],
+            'runtime' => ['runtime'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider cacheDataProvider
+     */
+    public function disableCoreCaches(string $identifier): void
+    {
+        $this->subject->disableCoreCaches();
+
+        /** @var CacheManager $cacheManager */
+        $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
+
+        $cache = $cacheManager->getCache($identifier);
+        self::assertInstanceOf(NullBackend::class, $cache->getBackend());
     }
 }


### PR DESCRIPTION
This is useful for functional testing where only parts of the Core
will be booted (and we do not need any caching anyway).