### PR TITLE
[BUGFIX] Disable the Core caches for some functional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.0 and 7.1 (#690)
 
 ### Fixed
-- Adapt the tests and testing framework to TYPO3 10LTS (#767, #777, #778, #779, #780)
+- Adapt the tests and testing framework to TYPO3 10LTS (#767, #777, #778, #779, #780, #783)
 - Recognize flexforms data converted to an array (#753)
 - Always display the incorrect value in the configuration check (#751)
 - Fix the `TemplateHelper` initialization (#740)

--- a/Tests/Functional/Configuration/ConfigurationRegistryTest.php
+++ b/Tests/Functional/Configuration/ConfigurationRegistryTest.php
@@ -31,12 +31,12 @@ class ConfigurationRegistryTest extends FunctionalTestCase
     {
         parent::setUp();
         $this->testingFramework = new TestingFramework('tx_oelib');
+        $this->testingFramework->disableCoreCaches();
     }
 
     protected function tearDown(): void
     {
         $this->testingFramework->cleanUpWithoutDatabase();
-        parent::tearDown();
     }
 
     ////////////////////////////////


### PR DESCRIPTION
This fixes these tests in TYPO3 10LTS.

Fixes #488