### PR TITLE
[TASK] Handle mapper names in a case-sensitives way in the `MapperRegistry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add Rector to the toolchain (#720, #722, #724)
 
 ### Changed
+- Handle mapper names in a case-sensitives way in the `MapperRegistry` (#787)
 - Allow psr/log in versions 2 and 3 as well (#785)
 - Switch the lazy loading callback to a closure (#775)
 - Make `TypoScriptConfiguration` and `ConfigurationProxy` immutable (#771)

--- a/Tests/Unit/Mapper/MapperRegistryTest.php
+++ b/Tests/Unit/Mapper/MapperRegistryTest.php
@@ -9,6 +9,9 @@ use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Tests\Unit\Mapper\Fixtures\TestingChildMapper;
 use OliverKlee\Oelib\Tests\Unit\Mapper\Fixtures\TestingMapper;
 
+/**
+ * @covers \OliverKlee\Oelib\Mapper\MapperRegistry
+ */
 class MapperRegistryTest extends UnitTestCase
 {
     protected function tearDown(): void
@@ -160,10 +163,7 @@ class MapperRegistryTest extends UnitTestCase
     public function getReturnsMapperSetViaSet(): void
     {
         $mapper = new TestingMapper();
-        MapperRegistry::set(
-            TestingMapper::class,
-            $mapper
-        );
+        MapperRegistry::set(TestingMapper::class, $mapper);
 
         self::assertSame(
             $mapper,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,17 +56,7 @@ parameters:
 			path: Classes/Mapper/FrontEndUserMapper.php
 
 		-
-			message: "#^Method OliverKlee\\\\Oelib\\\\Mapper\\\\MapperRegistry\\:\\:unifyClassName\\(\\) has parameter \\$className with generic class OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper but does not specify its types\\: M$#"
-			count: 1
-			path: Classes/Mapper/MapperRegistry.php
-
-		-
 			message: "#^Property OliverKlee\\\\Oelib\\\\Mapper\\\\MapperRegistry\\:\\:\\$mappers with generic class OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper does not specify its types\\: M$#"
-			count: 1
-			path: Classes/Mapper/MapperRegistry.php
-
-		-
-			message: "#^Unable to resolve the template type T in call to method static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\GeneralUtility\\:\\:makeInstance\\(\\)$#"
 			count: 1
 			path: Classes/Mapper/MapperRegistry.php
 


### PR DESCRIPTION
Composer autoloading it case-sensitive. So we must not lowercase the class names.

Fixes #786