### PR TITLE
[TASK] Deprecate `*LoginManager::getLoggedInUser()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Move PHPStan from PHIVE to Composer (#695)
 
 ### Deprecated
+- Deprecate `*LoginManager::getLoggedInUser()` (#803)
 - Deprecate the `PriceViewHelper` (#743)
 - Deprecate the `ReadOnlyRepository` trait (#729)
 

--- a/Classes/Authentication/BackEndLoginManager.php
+++ b/Classes/Authentication/BackEndLoginManager.php
@@ -76,6 +76,8 @@ class BackEndLoginManager implements LoginManager
      * @return AbstractModel|null the logged-in user, will be null if no user is logged in
      *
      * @throws \InvalidArgumentException
+     *
+     * @deprecated will be removed in oelib 5.0
      */
     public function getLoggedInUser(string $mapperName = BackEndUserMapper::class): ?AbstractModel
     {

--- a/Classes/Authentication/FrontEndLoginManager.php
+++ b/Classes/Authentication/FrontEndLoginManager.php
@@ -90,6 +90,8 @@ class FrontEndLoginManager implements LoginManager
      * @return AbstractModel|null the logged-in user, will be null if no user is logged in
      *
      * @throws \InvalidArgumentException
+     *
+     * @deprecated will be removed in oelib 5.0
      */
     public function getLoggedInUser(string $mapperName = FrontEndUserMapper::class): ?AbstractModel
     {

--- a/Classes/Interfaces/LoginManager.php
+++ b/Classes/Interfaces/LoginManager.php
@@ -38,6 +38,8 @@ interface LoginManager
      * @param class-string $mapperName mapper to use for getting the user model
      *
      * @return AbstractModel|null the logged-in user, will be null if no user is logged in
+     *
+     * @deprecated will be removed in oelib 5.0
      */
     public function getLoggedInUser(string $mapperName): ?AbstractModel;
 }


### PR DESCRIPTION
These methods cannot provide meaningful type annotations and hence
are a problem.