### PR TITLE
[CLEANUP] Improve type safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the (cosmetic) `TemplateHelper::cObj` (#814)
 
 ### Fixed
+- Improve type safety (#815)
 
 ## 4.0.0
 

--- a/Classes/Authentication/BackEndLoginManager.php
+++ b/Classes/Authentication/BackEndLoginManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OliverKlee\Oelib\Authentication;
 
 use OliverKlee\Oelib\Interfaces\LoginManager;
+use OliverKlee\Oelib\Mapper\AbstractDataMapper;
 use OliverKlee\Oelib\Mapper\BackEndUserMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\AbstractModel;
@@ -70,9 +71,11 @@ class BackEndLoginManager implements LoginManager
     /**
      * Gets the currently logged-in user.
      *
-     * @param class-string $mapperName mapper to use for getting the user model
+     * @template M of AbstractModel
      *
-     * @return AbstractModel|null the logged-in user, will be null if no user is logged in
+     * @param class-string<AbstractDataMapper<M>> $mapperName mapper to use for getting the user model
+     *
+     * @return M|null the logged-in user, will be null if no user is logged in
      *
      * @throws \InvalidArgumentException
      *
@@ -84,16 +87,22 @@ class BackEndLoginManager implements LoginManager
         if ($mapperName === '') {
             throw new \InvalidArgumentException('$mapperName must not be empty.', 1331318483);
         }
+
+        /** @var M|null $loggedInUser */
+        $loggedInUser = $this->loggedInUser;
+        if ($loggedInUser instanceof AbstractModel) {
+            return $loggedInUser;
+        }
+
         if (!$this->isLoggedIn()) {
             return null;
         }
-        if ($this->loggedInUser instanceof AbstractModel) {
-            return $this->loggedInUser;
-        }
 
-        $this->loggedInUser = MapperRegistry::get($mapperName)->find($this->getLoggedInUserUid());
+        /** @var M $loggedInUser */
+        $loggedInUser = MapperRegistry::get($mapperName)->find($this->getLoggedInUserUid());
+        $this->loggedInUser = $loggedInUser;
 
-        return $this->loggedInUser;
+        return $loggedInUser;
     }
 
     /**

--- a/Classes/Authentication/FrontEndLoginManager.php
+++ b/Classes/Authentication/FrontEndLoginManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OliverKlee\Oelib\Authentication;
 
 use OliverKlee\Oelib\Interfaces\LoginManager;
+use OliverKlee\Oelib\Mapper\AbstractDataMapper;
 use OliverKlee\Oelib\Mapper\FrontEndUserMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\AbstractModel;
@@ -84,9 +85,11 @@ class FrontEndLoginManager implements LoginManager
     /**
      * Gets the currently logged-in user.
      *
-     * @param class-string $mapperName mapper to use for getting the user model
+     * @template M of AbstractModel
      *
-     * @return AbstractModel|null the logged-in user, will be null if no user is logged in
+     * @param class-string<AbstractDataMapper<M>> $mapperName mapper to use for getting the user model
+     *
+     * @return M|null the logged-in user, will be null if no user is logged in
      *
      * @throws \InvalidArgumentException
      *
@@ -98,16 +101,22 @@ class FrontEndLoginManager implements LoginManager
         if ($mapperName === '') {
             throw new \InvalidArgumentException('$mapperName must not be empty.', 1331488730);
         }
-        if ($this->loggedInUser instanceof AbstractModel) {
-            return $this->loggedInUser;
+
+        /** @var M|null $loggedInUser */
+        $loggedInUser = $this->loggedInUser;
+        if ($loggedInUser instanceof AbstractModel) {
+            return $loggedInUser;
         }
+
         if (!$this->isLoggedIn()) {
             return null;
         }
 
-        $this->loggedInUser = MapperRegistry::get($mapperName)->find($this->getLoggedInUserUid());
+        /** @var M $loggedInUser */
+        $loggedInUser = MapperRegistry::get($mapperName)->find($this->getLoggedInUserUid());
+        $this->loggedInUser = $loggedInUser;
 
-        return $this->loggedInUser;
+        return $loggedInUser;
     }
 
     /**

--- a/Classes/Configuration/TypoScriptConfiguration.php
+++ b/Classes/Configuration/TypoScriptConfiguration.php
@@ -64,7 +64,7 @@ class TypoScriptConfiguration extends AbstractReadOnlyObjectWithPublicAccessors 
      *
      * @param string $key the key of the data item to get the array keys for, may be empty
      *
-     * @return array<int, string> the array keys of the data item for the key $key, may be empty
+     * @return array<int, string|int> the array keys of the data item for the key $key, may be empty
      */
     public function getArrayKeys(string $key = ''): array
     {

--- a/Classes/Geocoding/DummyGeocodingLookup.php
+++ b/Classes/Geocoding/DummyGeocodingLookup.php
@@ -32,7 +32,7 @@ class DummyGeocodingLookup implements GeocodingLookup
             return;
         }
 
-        if (!empty($this->coordinates)) {
+        if (isset($this->coordinates['latitude'], $this->coordinates['longitude'])) {
             $geoObject->setGeoCoordinates($this->coordinates);
         } else {
             $geoObject->setGeoError();

--- a/Classes/Geocoding/GoogleGeocoding.php
+++ b/Classes/Geocoding/GoogleGeocoding.php
@@ -135,7 +135,7 @@ class GoogleGeocoding implements GeocodingLookup
         while (true) {
             \usleep($delayInMicroseconds);
             $response = $this->sendRequest($url);
-            if ($response !== false) {
+            if (\is_string($response)) {
                 $resultParts = \json_decode($response, true);
                 $status = $resultParts['status'];
                 if ($status === self::STATUS_OK) {
@@ -179,7 +179,7 @@ class GoogleGeocoding implements GeocodingLookup
      *
      * @param string $url
      *
-     * @return string|bool string with the JSON result from the Google Maps server, or false if an error has occurred
+     * @return string|false string with the JSON result from the Google Maps server, or false if an error has occurred
      */
     protected function sendRequest(string $url)
     {

--- a/Classes/Http/HeaderProxyFactory.php
+++ b/Classes/Http/HeaderProxyFactory.php
@@ -59,7 +59,6 @@ class HeaderProxyFactory
      */
     public function getHeaderProxy(): HeaderProxy
     {
-        /** @var class-string $className */
         $className = $this->isTestMode ? HeaderCollector::class : RealHeaderProxy::class;
         if (!$this->headerProxy instanceof $className) {
             $this->headerProxy = GeneralUtility::makeInstance($className);

--- a/Classes/Interfaces/LoginManager.php
+++ b/Classes/Interfaces/LoginManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Oelib\Interfaces;
 
+use OliverKlee\Oelib\Mapper\AbstractDataMapper;
 use OliverKlee\Oelib\Model\AbstractModel;
 
 /**
@@ -35,9 +36,11 @@ interface LoginManager
     /**
      * Gets the currently logged-in user.
      *
-     * @param class-string $mapperName mapper to use for getting the user model
+     * @template M of AbstractModel
      *
-     * @return AbstractModel|null the logged-in user, will be null if no user is logged in
+     * @param class-string<AbstractDataMapper<M>> $mapperName mapper to use for getting the user model
+     *
+     * @return M|null the logged-in user, will be null if no user is logged in
      *
      * @deprecated will be removed in oelib 5.0
      */

--- a/Classes/Mapper/AbstractDataMapper.php
+++ b/Classes/Mapper/AbstractDataMapper.php
@@ -51,7 +51,7 @@ abstract class AbstractDataMapper
     protected $uidsOfMemoryOnlyDummyModels = [];
 
     /**
-     * @var array<non-empty-string, class-string>
+     * @var array<non-empty-string, class-string<AbstractDataMapper<AbstractModel>>>
      *      the (possible) relations of the created models in the format DB column name => mapper name
      */
     protected $relations = [];
@@ -1271,11 +1271,10 @@ abstract class AbstractDataMapper
     }
 
     /**
-     * Puts a model in the cache-by-keys (if the model has any non-empty
-     * additional keys).
+     * Puts a model in the cache-by-keys (if the model has any non-empty additional keys).
      *
      * @param M $model the model to cache
-     * @param array<string, string|int> $data the data of the model as it is in the DB, may be empty
+     * @param array<string, string|int|float> $data the data of the model as it is in the DB, may be empty
      */
     private function cacheModelByKeys(AbstractModel $model, array $data): void
     {
@@ -1301,7 +1300,7 @@ abstract class AbstractDataMapper
      * cacheModelByCompoundKey instead. So this method primarily is here for backwards compatibility.
      *
      * @param M $model the model to cache
-     * @param array<string, string|int> $data the data of the model as it is in the DB, may be empty
+     * @param array<string, string|int|float> $data the data of the model as it is in the DB, may be empty
      *
      * @see cacheModelByCompoundKey
      */
@@ -1317,7 +1316,7 @@ abstract class AbstractDataMapper
      * This method works automatically; it is not necessary to overwrite it.
      *
      * @param M $model the model to cache
-     * @param array<string, string|int> $data the data of the model as it is in the DB, may be empty
+     * @param array<string, string|int|float> $data the data of the model as it is in the DB, may be empty
      *
      * @throws \BadMethodCallException
      */

--- a/Classes/Templating/Template.php
+++ b/Classes/Templating/Template.php
@@ -64,9 +64,10 @@ class Template
      */
     public function processTemplateFromFile(string $fileName): void
     {
-        $this->processTemplate(
-            file_get_contents(GeneralUtility::getFileAbsFileName($fileName))
-        );
+        $fileContents = file_get_contents(GeneralUtility::getFileAbsFileName($fileName));
+        if (\is_string($fileContents)) {
+            $this->processTemplate($fileContents);
+        }
     }
 
     /**

--- a/Tests/Functional/Authentication/FrontEndLoginManagerTest.php
+++ b/Tests/Functional/Authentication/FrontEndLoginManagerTest.php
@@ -10,6 +10,7 @@ use OliverKlee\Oelib\Mapper\FrontEndUserMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\FrontEndUser;
 use OliverKlee\Oelib\Testing\TestingFramework;
+use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
@@ -78,7 +79,10 @@ class FrontEndLoginManagerTest extends FunctionalTestCase
     {
         $this->testingFramework->createFakeFrontEnd($this->testingFramework->createFrontEndPage());
 
-        $this->getFrontEndController()->fe_user->setAndSaveSessionData('oelib_test', 1);
+        $user = $this->getFrontEndController()->fe_user;
+        if ($user instanceof FrontendUserAuthentication) {
+            $user->setAndSaveSessionData('oelib_test', 1);
+        }
 
         self::assertFalse($this->subject->isLoggedIn());
     }
@@ -173,7 +177,10 @@ class FrontEndLoginManagerTest extends FunctionalTestCase
         $oldName = 'John Doe';
         $feUserUid = $this->testingFramework->createAndLoginFrontEndUser('', ['name' => $oldName]);
 
-        $this->getFrontEndController()->fe_user->user['name'] = 'Jane Doe';
+        $user = $this->getFrontEndController()->fe_user;
+        if ($user instanceof FrontendUserAuthentication) {
+            $user->user['name'] = 'Jane Doe';
+        }
         $this->testingFramework->changeRecord('fe_users', $feUserUid, ['name' => 'James Doe']);
 
         /** @var FrontEndUser $loggedInUser */

--- a/Tests/Functional/Mapper/AbstractDataMapperTest.php
+++ b/Tests/Functional/Mapper/AbstractDataMapperTest.php
@@ -2785,7 +2785,7 @@ class AbstractDataMapperTest extends FunctionalTestCase
         $this->subject->save($model);
 
         $row = $this->findRecordByUid($model->getUid());
-        self::assertSame('9.5', rtrim($row['decimal_data'], '0'));
+        self::assertSame('9.5', rtrim((string)$row['decimal_data'], '0'));
     }
 
     /**
@@ -2798,7 +2798,7 @@ class AbstractDataMapperTest extends FunctionalTestCase
         $this->subject->save($model);
 
         $row = $this->findRecordByUid($model->getUid());
-        self::assertSame('9.5', rtrim($row['string_data'], '0'));
+        self::assertSame('9.5', rtrim((string)$row['string_data'], '0'));
     }
 
     /**

--- a/Tests/Functional/Templating/TemplateHelperTest.php
+++ b/Tests/Functional/Templating/TemplateHelperTest.php
@@ -34,7 +34,9 @@ class TemplateHelperTest extends FunctionalTestCase
 
         /** @var TypoScriptFrontendController&ProphecySubjectInterface $frontEndController */
         $frontEndController = $this->prophesize(TypoScriptFrontendController::class)->reveal();
-        $frontEndController->cObj = $this->prophesize(ContentObjectRenderer::class)->reveal();
+        /** @var ContentObjectRenderer&ProphecySubjectInterface $contentObject */
+        $contentObject = $this->prophesize(ContentObjectRenderer::class)->reveal();
+        $frontEndController->cObj = $contentObject;
         $GLOBALS['TSFE'] = $frontEndController;
 
         $configuration = new DummyConfiguration(['enableConfigCheck' => true]);

--- a/Tests/Unit/Domain/Fixtures/LazyLoadingModel.php
+++ b/Tests/Unit/Domain/Fixtures/LazyLoadingModel.php
@@ -16,18 +16,18 @@ class LazyLoadingModel extends AbstractEntity
     use LazyLoadingProperties;
 
     /**
-     * @var EmptyModel|LazyLoadingProxy
+     * @var EmptyModel
+     * @phpstan-var EmptyModel|LazyLoadingProxy
      */
     protected $lazyProperty = null;
 
-    /**
-     * @return EmptyModel
-     */
     public function getLazyProperty(): EmptyModel
     {
         $this->loadLazyProperty('lazyProperty');
+        /** @var EmptyModel $property */
+        $property = $this->lazyProperty;
 
-        return $this->lazyProperty;
+        return $property;
     }
 
     /**

--- a/Tests/Unit/Templating/TemplateHelperTest.php
+++ b/Tests/Unit/Templating/TemplateHelperTest.php
@@ -32,7 +32,9 @@ class TemplateHelperTest extends UnitTestCase
 
         /** @var TypoScriptFrontendController&ProphecySubjectInterface $frontEndController */
         $frontEndController = $this->prophesize(TypoScriptFrontendController::class)->reveal();
-        $frontEndController->cObj = $this->prophesize(ContentObjectRenderer::class)->reveal();
+        /** @var ContentObjectRenderer&ProphecySubjectInterface $contentObject */
+        $contentObject = $this->prophesize(ContentObjectRenderer::class)->reveal();
+        $frontEndController->cObj = $contentObject;
         $GLOBALS['TSFE'] = $frontEndController;
 
         $this->subject = new TestingTemplateHelper([]);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,44 +1,19 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$className of static method OliverKlee\\\\Oelib\\\\Mapper\\\\MapperRegistry\\:\\:get\\(\\) expects class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\>, class\\-string given\\.$#"
+			message: "#^Default value of the parameter \\#1 \\$mapperName \\('OliverKlee\\\\\\\\Oelib\\\\\\\\Mapper\\\\\\\\BackEndUserMapper'\\) of method OliverKlee\\\\Oelib\\\\Authentication\\\\BackEndLoginManager\\:\\:getLoggedInUser\\(\\) is incompatible with type class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\.$#"
 			count: 1
 			path: Classes/Authentication/BackEndLoginManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of static method OliverKlee\\\\Oelib\\\\Mapper\\\\MapperRegistry\\:\\:get\\(\\) expects class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\>, class\\-string given\\.$#"
+			message: "#^Default value of the parameter \\#1 \\$mapperName \\('OliverKlee\\\\\\\\Oelib\\\\\\\\Mapper\\\\\\\\FrontEndUserMapper'\\) of method OliverKlee\\\\Oelib\\\\Authentication\\\\FrontEndLoginManager\\:\\:getLoggedInUser\\(\\) is incompatible with type class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\.$#"
 			count: 1
 			path: Classes/Authentication/FrontEndLoginManager.php
-
-		-
-			message: "#^Method OliverKlee\\\\Oelib\\\\Configuration\\\\TypoScriptConfiguration\\:\\:getArrayKeys\\(\\) should return array\\<int, string\\> but returns array\\<int, int\\|string\\>\\.$#"
-			count: 1
-			path: Classes/Configuration/TypoScriptConfiguration.php
 
 		-
 			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
 			count: 1
 			path: Classes/Domain/Repository/PageRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\$coordinates of method OliverKlee\\\\Oelib\\\\Interfaces\\\\Geo\\:\\:setGeoCoordinates\\(\\) expects array\\('latitude' \\=\\> float, 'longitude' \\=\\> float\\), array\\<string, float\\>&nonEmpty given\\.$#"
-			count: 1
-			path: Classes/Geocoding/DummyGeocodingLookup.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|true given\\.$#"
-			count: 1
-			path: Classes/Geocoding/GoogleGeocoding.php
-
-		-
-			message: "#^Method OliverKlee\\\\Oelib\\\\Http\\\\HeaderProxyFactory\\:\\:getHeaderProxy\\(\\) should return OliverKlee\\\\Oelib\\\\Http\\\\Interfaces\\\\HeaderProxy but returns object\\.$#"
-			count: 1
-			path: Classes/Http/HeaderProxyFactory.php
-
-		-
-			message: "#^Property OliverKlee\\\\Oelib\\\\Http\\\\HeaderProxyFactory\\:\\:\\$headerProxy \\(OliverKlee\\\\Oelib\\\\Http\\\\Interfaces\\\\HeaderProxy\\|null\\) does not accept object\\.$#"
-			count: 1
-			path: Classes/Http/HeaderProxyFactory.php
 
 		-
 			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
@@ -56,54 +31,9 @@ parameters:
 			path: Classes/Mapper/AbstractDataMapper.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of static method OliverKlee\\\\Oelib\\\\Mapper\\\\MapperRegistry\\:\\:get\\(\\) expects class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\>, class\\-string given\\.$#"
-			count: 8
-			path: Classes/Mapper/AbstractDataMapper.php
-
-		-
-			message: "#^Parameter \\#2 \\$data of method OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<M of OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\:\\:cacheModelByKeys\\(\\) expects array\\<string, int\\|string\\>, array\\<string, float\\|int\\|string\\> given\\.$#"
-			count: 1
-			path: Classes/Mapper/AbstractDataMapper.php
-
-		-
 			message: "#^Array \\(array\\<class\\-string, OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\) does not accept M of OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\.$#"
 			count: 2
 			path: Classes/Mapper/MapperRegistry.php
-
-		-
-			message: "#^Cannot call method getKey\\(\\) on string\\|TYPO3\\\\CMS\\\\Frontend\\\\Authentication\\\\FrontendUserAuthentication\\.$#"
-			count: 1
-			path: Classes/Session/Session.php
-
-		-
-			message: "#^Cannot call method setKey\\(\\) on string\\|TYPO3\\\\CMS\\\\Frontend\\\\Authentication\\\\FrontendUserAuthentication\\.$#"
-			count: 1
-			path: Classes/Session/Session.php
-
-		-
-			message: "#^Cannot call method storeSessionData\\(\\) on string\\|TYPO3\\\\CMS\\\\Frontend\\\\Authentication\\\\FrontendUserAuthentication\\.$#"
-			count: 1
-			path: Classes/Session/Session.php
-
-		-
-			message: "#^Parameter \\#1 \\$templateCode of method OliverKlee\\\\Oelib\\\\Templating\\\\Template\\:\\:processTemplate\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: Classes/Templating/Template.php
-
-		-
-			message: "#^Array \\(array\\<string, array\\<string, array\\>\\>\\) does not accept array\\<int\\|string, mixed\\>\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Cannot access property \\$user on string\\|TYPO3\\\\CMS\\\\Frontend\\\\Authentication\\\\FrontendUserAuthentication\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Cannot call method createUserSession\\(\\) on string\\|TYPO3\\\\CMS\\\\Frontend\\\\Authentication\\\\FrontendUserAuthentication\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
 
 		-
 			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\|int\\.$#"
@@ -111,74 +41,9 @@ parameters:
 			path: Classes/Testing/TestingFramework.php
 
 		-
-			message: "#^Cannot call method fetchGroupData\\(\\) on string\\|TYPO3\\\\CMS\\\\Frontend\\\\Authentication\\\\FrontendUserAuthentication\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Cannot call method logoff\\(\\) on string\\|TYPO3\\\\CMS\\\\Frontend\\\\Authentication\\\\FrontendUserAuthentication\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Parameter \\#1 \\$rawData of method OliverKlee\\\\Oelib\\\\Testing\\\\TestingFramework\\:\\:normalizeDatabaseRow\\(\\) expects array\\<string, bool\\|int\\|string\\>, array\\<string, bool\\|float\\|int\\|string\\> given\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Parameter \\#2 \\$encoding of function mb_strlen expects string, string\\|false given\\.$#"
-			count: 2
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Parameter \\#2 \\$start of function mb_substr expects int, int\\|false given\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Parameter \\#3 \\$length of function mb_substr expects int\\|null, int\\|false given\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Parameter \\#4 \\$encoding of function mb_substr expects string, string\\|false given\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Static property OliverKlee\\\\Oelib\\\\Testing\\\\TestingFramework\\:\\:\\$tableNameCache \\(array\\<string, array\\>\\) does not accept array\\<int\\|string, mixed\\>\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^Cannot access property \\$user on string\\|TYPO3\\\\CMS\\\\Frontend\\\\Authentication\\\\FrontendUserAuthentication\\.$#"
-			count: 1
-			path: Tests/Functional/Authentication/FrontEndLoginManagerTest.php
-
-		-
-			message: "#^Cannot call method setAndSaveSessionData\\(\\) on string\\|TYPO3\\\\CMS\\\\Frontend\\\\Authentication\\\\FrontendUserAuthentication\\.$#"
-			count: 1
-			path: Tests/Functional/Authentication/FrontEndLoginManagerTest.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$objectManager contains generic class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager but does not specify its types\\: T$#"
 			count: 1
 			path: Tests/Functional/Domain/Repository/GermanZipCodeRepositoryTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of function rtrim expects string, int\\|string given\\.$#"
-			count: 2
-			path: Tests/Functional/Mapper/AbstractDataMapperTest.php
-
-		-
-			message: "#^Property TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\:\\:\\$cObj \\(TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\) does not accept object\\.$#"
-			count: 1
-			path: Tests/Functional/Templating/TemplateHelperTest.php
-
-		-
-			message: "#^Method OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Domain\\\\Fixtures\\\\LazyLoadingModel\\:\\:getLazyProperty\\(\\) should return OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Domain\\\\Fixtures\\\\EmptyModel but returns OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Domain\\\\Fixtures\\\\EmptyModel\\|TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\LazyLoadingProxy\\.$#"
-			count: 1
-			path: Tests/Unit/Domain/Fixtures/LazyLoadingModel.php
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$objectManagerStub contains generic interface TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManagerInterface but does not specify its types\\: T$#"
@@ -194,9 +59,4 @@ parameters:
 			message: "#^PHPDoc tag @var for variable \\$objectManagerStub contains generic interface TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManagerInterface but does not specify its types\\: T$#"
 			count: 1
 			path: Tests/Unit/Domain/Repository/Traits/ReadOnlyTest.php
-
-		-
-			message: "#^Property TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\:\\:\\$cObj \\(TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\) does not accept object\\.$#"
-			count: 1
-			path: Tests/Unit/Templating/TemplateHelperTest.php
 


### PR DESCRIPTION
Improve the type annotations and the type checks.

This fixes a bunch of level 7 problems detected by PHPStan.