### PR TITLE
[CLEANUP] Drop redundant `@var` annotations

### DIFF
--- a/Classes/Authentication/FrontEndLoginManager.php
+++ b/Classes/Authentication/FrontEndLoginManager.php
@@ -63,10 +63,7 @@ class FrontEndLoginManager implements LoginManager
 
     private function getContext(): Context
     {
-        /** @var Context $context */
-        $context = GeneralUtility::makeInstance(Context::class);
-
-        return $context;
+        return GeneralUtility::makeInstance(Context::class);
     }
 
     /**

--- a/Classes/Configuration/AbstractConfigurationCheck.php
+++ b/Classes/Configuration/AbstractConfigurationCheck.php
@@ -169,9 +169,7 @@ abstract class AbstractConfigurationCheck
      */
     private function getDbColumnNames(string $tableName): array
     {
-        /** @var ConnectionPool $connectionPool */
-        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-        $connection = $connectionPool->getConnectionForTable($tableName);
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($tableName);
         $statement = $connection->query('SHOW FULL COLUMNS FROM `' . $tableName . '`');
         $columns = [];
         foreach ($statement->fetchAll() as $row) {
@@ -529,9 +527,7 @@ abstract class AbstractConfigurationCheck
      */
     public function checkIsValidDefaultFromEmailAddress(): bool
     {
-        /** @var SystemEmailFromBuilder $emailBuilder */
-        $emailBuilder = GeneralUtility::makeInstance(SystemEmailFromBuilder::class);
-        $okay = $emailBuilder->canBuild();
+        $okay = GeneralUtility::makeInstance(SystemEmailFromBuilder::class)->canBuild();
 
         if (!$okay) {
             $this->addWarning(

--- a/Classes/Configuration/ConfigurationProxy.php
+++ b/Classes/Configuration/ConfigurationProxy.php
@@ -118,9 +118,8 @@ class ConfigurationProxy extends AbstractReadOnlyObjectWithPublicAccessors imple
             isset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extensionKey])
             && \is_array($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$this->extensionKey])
         ) {
-            /** @var ExtensionConfiguration $extensionConfiguration */
-            $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
-            $this->configuration = $extensionConfiguration->get($this->extensionKey);
+            $this->configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class)
+                ->get($this->extensionKey);
         } else {
             $this->configuration = [];
         }

--- a/Classes/Configuration/ConfigurationRegistry.php
+++ b/Classes/Configuration/ConfigurationRegistry.php
@@ -146,7 +146,6 @@ class ConfigurationRegistry
             $data = $data[$namespacePart . '.'];
         }
 
-        /** @var TypoScriptConfiguration $configuration */
         $configuration = GeneralUtility::makeInstance(TypoScriptConfiguration::class);
         $configuration->setData($data);
         return $configuration;
@@ -169,14 +168,11 @@ class ConfigurationRegistry
             return $this->getFrontEndController()->tmpl->setup;
         }
 
-        /** @var TemplateService $template */
         $template = GeneralUtility::makeInstance(TemplateService::class);
         $template->tt_track = false;
 
-        /** @var RootlineUtility $rootLineUtility */
-        $rootLineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pageUid);
         try {
-            $rootLine = $rootLineUtility->get();
+            $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $pageUid)->get();
         } catch (PageNotFoundException $e) {
             $rootLine = [];
         }

--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -67,9 +67,6 @@ class PageRepository implements SingletonInterface
 
     private function getConnectionPool(): ConnectionPool
     {
-        /** @var ConnectionPool $pool */
-        $pool = GeneralUtility::makeInstance(ConnectionPool::class);
-
-        return $pool;
+        return GeneralUtility::makeInstance(ConnectionPool::class);
     }
 }

--- a/Classes/Email/SystemEmailFromBuilder.php
+++ b/Classes/Email/SystemEmailFromBuilder.php
@@ -47,13 +47,10 @@ class SystemEmailFromBuilder
             );
         }
 
-        /** @var GeneralEmailRole $email */
-        $email = GeneralUtility::makeInstance(
+        return GeneralUtility::makeInstance(
             GeneralEmailRole::class,
             (string)MailUtility::getSystemFromAddress(),
             (string)MailUtility::getSystemFromName()
         );
-
-        return $email;
     }
 }

--- a/Classes/Mapper/AbstractDataMapper.php
+++ b/Classes/Mapper/AbstractDataMapper.php
@@ -829,7 +829,6 @@ abstract class AbstractDataMapper
 
                 $relatedData = $data[$key];
                 if ($relatedData instanceof Collection) {
-                    /** @var Collection<AbstractModel> $relatedData */
                     $this->saveManyToManyAndCommaSeparatedRelatedModels($relatedData, MapperRegistry::get($relation));
                 }
             }
@@ -974,9 +973,7 @@ abstract class AbstractDataMapper
             $relatedMapper = MapperRegistry::get($relation);
             $foreignField = $relationConfiguration['foreign_field'];
             if (\strncmp($foreignField, 'tx_', 3) === 0) {
-                $foreignKey = ucfirst(
-                    preg_replace('/tx_[a-z]+_/', '', $foreignField)
-                );
+                $foreignKey = ucfirst(preg_replace('/tx_[a-z]+_/', '', $foreignField));
             } else {
                 $foreignKey = ucfirst($foreignField);
             }
@@ -1542,9 +1539,6 @@ abstract class AbstractDataMapper
      */
     private function getConnectionPool(): ConnectionPool
     {
-        /** @var ConnectionPool $pool */
-        $pool = GeneralUtility::makeInstance(ConnectionPool::class);
-
-        return $pool;
+        return GeneralUtility::makeInstance(ConnectionPool::class);
     }
 }

--- a/Classes/Model/FrontEndUser.php
+++ b/Classes/Model/FrontEndUser.php
@@ -657,10 +657,7 @@ class FrontEndUser extends AbstractModel implements MailRole, Address
         }
 
         try {
-            /** @var CountryMapper $countryMapper */
-            $countryMapper = MapperRegistry::get(CountryMapper::class);
-            /** @var Country $country */
-            $country = $countryMapper->findByIsoAlpha3Code($countryCode);
+            $country = MapperRegistry::get(CountryMapper::class)->findByIsoAlpha3Code($countryCode);
         } catch (NotFoundException $exception) {
             $country = null;
         }

--- a/Classes/Templating/TemplateRegistry.php
+++ b/Classes/Templating/TemplateRegistry.php
@@ -84,7 +84,6 @@ class TemplateRegistry
     public function getByFileName(string $fileName): Template
     {
         if (!isset($this->templates[$fileName])) {
-            /** @var Template $template */
             $template = GeneralUtility::makeInstance(Template::class);
 
             if ($fileName !== '') {

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -219,9 +219,7 @@ final class TestingFramework
         $rootLineCacheConfiguration['backend'] = NullBackend::class;
         $rootLineCacheConfiguration['options'] = [];
         $cacheConfigurations = [$cacheKey => $rootLineCacheConfiguration];
-        /** @var CacheManager $cacheManager */
-        $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
-        $cacheManager->setCacheConfigurations($cacheConfigurations);
+        GeneralUtility::makeInstance(CacheManager::class)->setCacheConfigurations($cacheConfigurations);
     }
 
     private function initializeDatabase(): void
@@ -346,10 +344,7 @@ final class TestingFramework
      */
     private function getConnectionPool(): ConnectionPool
     {
-        /** @var ConnectionPool $pool */
-        $pool = GeneralUtility::makeInstance(ConnectionPool::class);
-
-        return $pool;
+        return GeneralUtility::makeInstance(ConnectionPool::class);
     }
 
     /**
@@ -1162,7 +1157,6 @@ final class TestingFramework
         $GLOBALS['_SERVER']['HTTP_HOST'] = 'typo3-test.dev';
         if (Typo3Version::isAtLeast(10)) {
             $this->disableCoreCaches();
-            /** @var TypoScriptFrontendController $frontEnd */
             $frontEnd = GeneralUtility::makeInstance(
                 TypoScriptFrontendController::class,
                 $GLOBALS['TYPO3_CONF_VARS'],
@@ -1170,7 +1164,6 @@ final class TestingFramework
                 new SiteLanguage(0, 'en_US.utf8', new Uri(), [])
             );
         } else {
-            /** @var TypoScriptFrontendController $frontEnd */
             $frontEnd = GeneralUtility::makeInstance(
                 TypoScriptFrontendController::class,
                 $GLOBALS['TYPO3_CONF_VARS'],
@@ -1180,7 +1173,6 @@ final class TestingFramework
         }
         $GLOBALS['TSFE'] = $frontEnd;
 
-        /** @var FrontendUserAuthentication $frontEndUser */
         $frontEndUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
         $frontEndUser->start();
         $frontEndUser->unpack_uc();
@@ -1195,10 +1187,8 @@ final class TestingFramework
         $frontEnd->config = [];
 
         if (($pageUid > 0) && in_array('sys_template', $this->dirtySystemTables, true)) {
-            /** @var RootlineUtility $rootLineUtility */
-            $rootLineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pageUid);
             try {
-                $rootLine = $rootLineUtility->get();
+                $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $pageUid)->get();
             } catch (PageNotFoundException $e) {
                 $rootLine = [];
             }
@@ -1933,9 +1923,7 @@ final class TestingFramework
             return;
         }
 
-        /** @var NullBackend $backEnd */
         $backEnd = GeneralUtility::makeInstance(NullBackend::class, 'Testing');
-        /** @var VariableFrontend $frontEnd */
         $frontEnd = GeneralUtility::makeInstance(VariableFrontend::class, $cacheKey, $backEnd);
         $cacheManager->registerCache($frontEnd);
     }
@@ -1947,10 +1935,7 @@ final class TestingFramework
 
     private function getCacheManager(): CacheManager
     {
-        /** @var CacheManager $cacheManager */
-        $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
-
-        return $cacheManager;
+        return GeneralUtility::makeInstance(CacheManager::class);
     }
 
     /**

--- a/Classes/ViewHelpers/PriceViewHelper.php
+++ b/Classes/ViewHelpers/PriceViewHelper.php
@@ -56,9 +56,7 @@ class PriceViewHelper extends AbstractViewHelper
         }
 
         try {
-            /** @var CurrencyMapper $mapper */
-            $mapper = MapperRegistry::get(CurrencyMapper::class);
-            $this->currency = $mapper->findByIsoAlpha3Code($isoAlpha3Code);
+            $this->currency = MapperRegistry::get(CurrencyMapper::class)->findByIsoAlpha3Code($isoAlpha3Code);
         } catch (NotFoundException $exception) {
             $this->currency = null;
         }

--- a/Classes/Visibility/Tree.php
+++ b/Classes/Visibility/Tree.php
@@ -56,7 +56,6 @@ class Tree
         Node $parentNode
     ): void {
         foreach ($treeStructure as $nodeKey => $nodeContents) {
-            /** @var Node $childNode */
             $childNode = GeneralUtility::makeInstance(Node::class);
             $parentNode->addChild($childNode);
 

--- a/Documentation/Tutorial/UsingAndPersistingDomainModels/Index.rst
+++ b/Documentation/Tutorial/UsingAndPersistingDomainModels/Index.rst
@@ -144,7 +144,7 @@ model’s data is never expected to be loaded or saved):
 
 ::
 
-   $realtyObject = tx_oelib_MapperRegistry::get('tx_realty_Mapper_RealtyObject')
+   $realtyObject = MapperRegistry::get('tx_realty_Mapper_RealtyObject')
        ->getNewGhost();
 
 If you need a model with data and you’re not testing any m:n or 1:n
@@ -152,7 +152,7 @@ relations, you can fill the model with data:
 
 ::
 
-   $realtyObject = tx_oelib_MapperRegistry::get('tx_realty_Mapper_RealtyObject')
+   $realtyObject = MapperRegistry::get('tx_realty_Mapper_RealtyObject')
        ->getLoadedTestingModel(array(‘title’ => ‘nice house’, ‘city’ => $cityUid));
 
 
@@ -182,7 +182,7 @@ modified looks like this:
 
 ::
 
-   tx_oelib_MapperRegistry::get('tx_realty_Mapper_RealtyObject')->save($model);
+   MapperRegistry::get('tx_realty_Mapper_RealtyObject')->save($model);
 
 
 Creating a new model in memory and saving it looks like this:
@@ -213,7 +213,7 @@ $tender->setData(array(
 
 $tender->markAsDirty();
 
-MapperRegistry::get('tx\_geotenders\_Mapper\_Tender')->save($tender);
+MapperRegistry::get(TenderMapper::class)->save($tender);
 
 Related records are automatically saved recursively. Unmodified record
 are not saved.

--- a/Tests/Functional/Authentication/BackEndLoginManagerTest.php
+++ b/Tests/Functional/Authentication/BackEndLoginManagerTest.php
@@ -36,9 +36,7 @@ final class BackEndLoginManagerTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        /** @var BackEndUserMapper $backEndUserMapper */
-        $backEndUserMapper = MapperRegistry::get(BackEndUserMapper::class);
-        $this->backEndUserMapper = $backEndUserMapper;
+        $this->backEndUserMapper = MapperRegistry::get(BackEndUserMapper::class);
 
         $this->subject = BackEndLoginManager::getInstance();
     }

--- a/Tests/Functional/Authentication/FrontEndLoginManagerTest.php
+++ b/Tests/Functional/Authentication/FrontEndLoginManagerTest.php
@@ -160,10 +160,7 @@ class FrontEndLoginManagerTest extends FunctionalTestCase
         $this->testingFramework->createFakeFrontEnd($this->testingFramework->createFrontEndPage());
         $uid = $this->testingFramework->createAndLoginFrontEndUser();
 
-        /** @var FrontEndUserMapper $mapper */
-        $mapper = MapperRegistry::get(FrontEndUserMapper::class);
-        /** @var FrontEndUser $user */
-        $user = $mapper->find($uid);
+        $user = MapperRegistry::get(FrontEndUserMapper::class)->find($uid);
 
         self::assertSame($user, $this->subject->getLoggedInUser());
     }

--- a/Tests/Functional/Domain/Repository/GermanZipCodeRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/GermanZipCodeRepositoryTest.php
@@ -26,7 +26,6 @@ class GermanZipCodeRepositoryTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        /** @var ObjectManager $objectManager */
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $this->subject = $objectManager->get(GermanZipCodeRepository::class);
         $this->importDataSet(__DIR__ . '/Fixtures/ZipCodes.xml');

--- a/Tests/Functional/Mapper/AbstractDataMapperTest.php
+++ b/Tests/Functional/Mapper/AbstractDataMapperTest.php
@@ -39,9 +39,7 @@ class AbstractDataMapperTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        /** @var TestingMapper $subject */
-        $subject = MapperRegistry::get(TestingMapper::class);
-        $this->subject = $subject;
+        $this->subject = MapperRegistry::get(TestingMapper::class);
     }
 
     protected function tearDown(): void

--- a/Tests/Functional/Model/AbstractModelTest.php
+++ b/Tests/Functional/Model/AbstractModelTest.php
@@ -40,12 +40,9 @@ class AbstractModelTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        /** @var TestingMapper $dataMapper */
-        $dataMapper = MapperRegistry::get(TestingMapper::class);
-        $this->dataMapper = $dataMapper;
+        $this->dataMapper = MapperRegistry::get(TestingMapper::class);
 
         $uid = $this->createTestRecord();
-        /** @var TestingModel $subject */
         $subject = $this->dataMapper->find($uid);
         $this->subject = $subject;
     }

--- a/Tests/Functional/Model/BackEndUserTest.php
+++ b/Tests/Functional/Model/BackEndUserTest.php
@@ -118,10 +118,10 @@ class BackEndUserTest extends FunctionalTestCase
      */
     public function getAllGroupsForGroupWithSubsubgroupContainsSubsubgroup(): void
     {
-        $subsubgroup = MapperRegistry::get(BackEndUserGroupMapper::class)
+        $subSubGroup = MapperRegistry::get(BackEndUserGroupMapper::class)
             ->getLoadedTestingModel([]);
         $subgroup = MapperRegistry::get(BackEndUserGroupMapper::class)
-            ->getLoadedTestingModel(['subgroup' => $subsubgroup->getUid()]);
+            ->getLoadedTestingModel(['subgroup' => $subSubGroup->getUid()]);
         $group = MapperRegistry::get(BackEndUserGroupMapper::class)
             ->getLoadedTestingModel(['subgroup' => $subgroup->getUid()]);
         $groups = new Collection();
@@ -129,7 +129,7 @@ class BackEndUserTest extends FunctionalTestCase
         $this->subject->setData(['usergroup' => $groups]);
 
         self::assertTrue(
-            $this->subject->getAllGroups()->hasUid($subsubgroup->getUid())
+            $this->subject->getAllGroups()->hasUid($subSubGroup->getUid())
         );
     }
 

--- a/Tests/Functional/Model/FrontEndUserTest.php
+++ b/Tests/Functional/Model/FrontEndUserTest.php
@@ -8,7 +8,6 @@ use Nimut\TestingFramework\Exception\Exception as NimutException;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use OliverKlee\Oelib\Mapper\CountryMapper;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
-use OliverKlee\Oelib\Model\Country;
 use OliverKlee\Oelib\Model\FrontEndUser;
 
 class FrontEndUserTest extends FunctionalTestCase
@@ -68,10 +67,7 @@ class FrontEndUserTest extends FunctionalTestCase
     {
         $this->importStaticData();
 
-        /** @var CountryMapper $mapper */
-        $mapper = MapperRegistry::get(CountryMapper::class);
-        /** @var Country $country */
-        $country = $mapper->find(54);
+        $country = MapperRegistry::get(CountryMapper::class)->find(54);
         $this->subject->setData(['static_info_country' => $country->getIsoAlpha3Code()]);
 
         self::assertSame($country, $this->subject->getCountry());
@@ -84,10 +80,7 @@ class FrontEndUserTest extends FunctionalTestCase
     {
         $this->importStaticData();
 
-        /** @var CountryMapper $mapper */
-        $mapper = MapperRegistry::get(CountryMapper::class);
-        /** @var Country $country */
-        $country = $mapper->find(54);
+        $country = MapperRegistry::get(CountryMapper::class)->find(54);
 
         $this->subject->setCountry($country);
 
@@ -133,10 +126,7 @@ class FrontEndUserTest extends FunctionalTestCase
     {
         $this->importStaticData();
 
-        /** @var CountryMapper $mapper */
-        $mapper = MapperRegistry::get(CountryMapper::class);
-        /** @var Country $country */
-        $country = $mapper->find(54);
+        $country = MapperRegistry::get(CountryMapper::class)->find(54);
         $this->subject->setCountry($country);
 
         self::assertTrue($this->subject->hasCountry());

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -59,10 +59,7 @@ final class TestingFrameworkTest extends FunctionalTestCase
 
     private function getContext(): Context
     {
-        /** @var Context $context */
-        $context = GeneralUtility::makeInstance(Context::class);
-
-        return $context;
+        return GeneralUtility::makeInstance(Context::class);
     }
 
     /**
@@ -2836,7 +2833,6 @@ final class TestingFrameworkTest extends FunctionalTestCase
     {
         $this->subject->disableCoreCaches();
 
-        /** @var CacheManager $cacheManager */
         $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
 
         $cache = $cacheManager->getCache($identifier);

--- a/Tests/Unit/Templating/TemplateHelperTest.php
+++ b/Tests/Unit/Templating/TemplateHelperTest.php
@@ -26,7 +26,6 @@ class TemplateHelperTest extends UnitTestCase
 
     protected function setUp(): void
     {
-        /** @var CacheManager $cacheManager */
         $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
         $cacheManager->setCacheConfigurations(['l10n' => ['backend' => NullBackend::class]]);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -126,11 +126,6 @@ parameters:
 			path: Tests/Functional/Authentication/FrontEndLoginManagerTest.php
 
 		-
-			message: "#^PHPDoc tag @var for variable \\$objectManager contains generic class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager but does not specify its types\\: T$#"
-			count: 1
-			path: Tests/Functional/Domain/Repository/GermanZipCodeRepositoryTest.php
-
-		-
 			message: "#^Cannot call method getTitle\\(\\) on OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Model\\\\Fixtures\\\\TestingModel\\|null\\.$#"
 			count: 2
 			path: Tests/Functional/Mapper/AbstractDataMapperTest.php


### PR DESCRIPTION
Some type annotations now can be deduced using the generics.

Fixes #796