### PR TITLE
[TASK] Clean up the conflicts section in the `composer.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Clean up the conflicts section in the `composer.json` (#851)
 - Bump the version number of the static_info_tables suggestion (#850)
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -51,9 +51,6 @@
 		"squizlabs/php_codesniffer": "^3.6.1",
 		"typo3/cms-extensionmanager": "^9.5 || ^10.4"
 	},
-	"conflict": {
-		"typo3/cms-composer-installers": "<1.4.6"
-	},
 	"replace": {
 		"typo3-ter/oelib": "self.version"
 	},


### PR DESCRIPTION
The danger of someone using an ancient version of the TYPO3
composer installer is pretty much non-existent anymore. So we don't
need this conflict anymore.