### PR TITLE
[BUGFIX] Require TYPO3 >= 9.5.16 to avoid missing classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Require TYPO3 >= 9.5.16 to avoid missing classes (#884)
 
 ## 4.1.2
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"ext-zip": "*",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",
 		"swiftmailer/swiftmailer": "^5.4",
-		"typo3/cms-core": "^9.5.7 || ^10.4",
+		"typo3/cms-core": "^9.5.16 || ^10.4",
 		"typo3/cms-extbase": "^9.5 || ^10.4",
 		"typo3/cms-fluid": "^9.5 || ^10.4",
 		"typo3/cms-frontend": "^9.5 || ^10.4",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,7 +8,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'php' => '7.2.0-8.0.99',
-            'typo3' => '9.5.0-10.4.99',
+            'typo3' => '9.5.16-10.4.99',
             'extbase' => '9.5.0-10.4.99',
         ],
         'conflicts' => [


### PR DESCRIPTION
We are using the `Typo3Version` class which was added in TYPO3
9.5.16.