### PR TITLE
[BUGFIX] Avoid DI-related exception in TYPO3 10LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Avoid DI-related exception in TYPO3 10LTS (#885)
 - Require TYPO3 >= 9.5.16 to avoid missing classes (#884)
 
 ## 4.1.2

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"ext-zip": "*",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",
 		"swiftmailer/swiftmailer": "^5.4",
-		"typo3/cms-core": "^9.5.16 || ^10.4",
+		"typo3/cms-core": "^9.5.16 || ^10.4.1",
 		"typo3/cms-extbase": "^9.5 || ^10.4",
 		"typo3/cms-fluid": "^9.5 || ^10.4",
 		"typo3/cms-frontend": "^9.5 || ^10.4",


### PR DESCRIPTION
Require TYPO3 ^10.4.1 for TYPO3 10LTS to avoid running into a problem
where the `Query` instance cannot be injected.