### PR TITLE
[BUGFIX] Stop using the deprecated `ObjectManager` in a trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+Stop using the deprecated `ObjectManager` (#891)
 
 ## 4.1.3
 

--- a/Classes/Domain/Repository/Traits/StoragePageAgnostic.php
+++ b/Classes/Domain/Repository/Traits/StoragePageAgnostic.php
@@ -11,10 +11,19 @@ use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
  */
 trait StoragePageAgnostic
 {
+    /**
+     * @var QuerySettingsInterface
+     */
+    private $querySettings;
+
+    public function injectQuerySettings(QuerySettingsInterface $querySettings): void
+    {
+        $this->querySettings = $querySettings;
+    }
+
     public function initializeObject(): void
     {
-        /** @var QuerySettingsInterface $querySettings */
-        $querySettings = $this->objectManager->get(QuerySettingsInterface::class);
+        $querySettings = clone $this->querySettings;
         $querySettings->setRespectStoragePage(false);
         $this->setDefaultQuerySettings($querySettings);
     }


### PR DESCRIPTION
`ObjectManager` has been deprecated in TYPO3 V11.