### PR TITLE
[TASK] Harden `AbstractDataMapper::findByPageUid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Harden `AbstractDataMapper::findByPageUid` (#911)
 - Fix more PHPStan warnings (#902)
 
 ## 4.1.4

--- a/Classes/Mapper/AbstractDataMapper.php
+++ b/Classes/Mapper/AbstractDataMapper.php
@@ -1210,16 +1210,18 @@ abstract class AbstractDataMapper
     }
 
     /**
-     * @param QueryBuilder $query
+     * @param QueryBuilder $queryBuilder
      * @param string $pageUids comma-separated list of page UIDs
      */
-    protected function addPageUidRestriction(QueryBuilder $query, string $pageUids): void
+    protected function addPageUidRestriction(QueryBuilder $queryBuilder, string $pageUids): void
     {
         if (\in_array($pageUids, ['', '0', 0], true)) {
             return;
         }
 
-        $query->andWhere($query->expr()->in('pid', GeneralUtility::intExplode(',', $pageUids)));
+        $intUids = GeneralUtility::intExplode(',', $pageUids);
+        $pagesParameter = $queryBuilder->createNamedParameter($intUids, Connection::PARAM_INT_ARRAY);
+        $queryBuilder->andWhere($queryBuilder->expr()->in('pid', $pagesParameter));
     }
 
     /**

--- a/Tests/Functional/Mapper/AbstractDataMapperTest.php
+++ b/Tests/Functional/Mapper/AbstractDataMapperTest.php
@@ -3057,6 +3057,34 @@ class AbstractDataMapperTest extends FunctionalTestCase
         self::assertSame($uid, $result->getUid());
     }
 
+    /**
+     * @test
+     */
+    public function findByPageUidSilentlyIgnoresExtraneousCommas(): void
+    {
+        $this->getDatabaseConnection()->insertArray('tx_oelib_test', ['pid' => 2]);
+        $uid = (int)$this->getDatabaseConnection()->lastInsertId();
+
+        $result = $this->subject->findByPageUid(',1,2,,')->first();
+
+        self::assertInstanceOf(TestingModel::class, $result);
+        self::assertSame($uid, $result->getUid());
+    }
+
+    /**
+     * @test
+     */
+    public function findByPageUidSilentlyIgnoresNonIntegerStrings(): void
+    {
+        $this->getDatabaseConnection()->insertArray('tx_oelib_test', ['pid' => 2]);
+        $uid = (int)$this->getDatabaseConnection()->lastInsertId();
+
+        $result = $this->subject->findByPageUid('1,2,Club-Mate')->first();
+
+        self::assertInstanceOf(TestingModel::class, $result);
+        self::assertSame($uid, $result->getUid());
+    }
+
     /////////////////////////////////////
     // Tests concerning additional keys
     /////////////////////////////////////


### PR DESCRIPTION
The method already worked fine (as proven by the new tests),
but the new implementation is cleaner.

Fixes #909