### PR TITLE
[CLEANUP] Drop the outdated SwiftMailer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Deprecate `GoogleMapsViewHelper` (#910)
 
 ### Removed
+- Drop the outdated SwiftMailer dependency (#913)
 
 ### Fixed
 - Harden `AbstractDataMapper::findByPageUid` (#911)

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
 		"ext-zip": "*",
 		"doctrine/dbal": "^2.10",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",
-		"swiftmailer/swiftmailer": "^5.4",
 		"typo3/cms-core": "^9.5.16 || ^10.4.1",
 		"typo3/cms-extbase": "^9.5 || ^10.4",
 		"typo3/cms-fluid": "^9.5 || ^10.4",


### PR DESCRIPTION
After the removal of the email-related classes in #694,
the SwiftMailer dependency is no longer necessary.