### PR TITLE
[BUGFIX] Allow a `TemplateHelper` Configuration without cObj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the outdated SwiftMailer dependency (#913)
 
 ### Fixed
+- Allow a `TemplateHelper` Configuration without cObj (#914)
 - Harden `AbstractDataMapper::findByPageUid` (#911)
 - Fix more PHPStan warnings (#902)
 

--- a/Classes/Templating/TemplateHelper.php
+++ b/Classes/Templating/TemplateHelper.php
@@ -133,8 +133,8 @@ class TemplateHelper extends SalutationSwitcher
      * @param string $fieldName field name to extract
      * @param string $sheet sheet pointer, eg. "sDEF"
      * @param bool $isFileName whether this is a filename, which has to be combined with a path
-     * @param bool $ignoreFlexform
-     *        whether to ignore the flexform values and just get the settings from TypoScript, may be empty
+     * @param bool $ignoreFlexform whether to ignore the flexform values and just get the settings from TypoScript,
+     *        may be empty
      *
      * @return string the value of the corresponding flexforms or TypoScript setup entry (may be empty)
      */
@@ -144,9 +144,10 @@ class TemplateHelper extends SalutationSwitcher
         bool $isFileName = false,
         bool $ignoreFlexform = false
     ): string {
+        $configurationValueFromTypoScript = (string)($this->conf[$fieldName] ?? '');
         $contentObject = $this->cObj;
         if (!$contentObject instanceof ContentObjectRenderer) {
-            throw new \RuntimeException('cObj is not set.', 1646325881);
+            return $configurationValueFromTypoScript;
         }
 
         $flexFormsData = $contentObject->data['pi_flexform'] ?? null;
@@ -159,9 +160,8 @@ class TemplateHelper extends SalutationSwitcher
         if ($isFileName && $flexFormsValue !== null && $flexFormsValue !== '') {
             $flexFormsValue = $this->addPathToFileName($flexFormsValue);
         }
-        $confValue = (string)($this->conf[$fieldName] ?? '');
 
-        return $flexFormsValue ?: $confValue;
+        return $flexFormsValue ?: $configurationValueFromTypoScript;
     }
 
     /**

--- a/Tests/Unit/Templating/TemplateHelperTest.php
+++ b/Tests/Unit/Templating/TemplateHelperTest.php
@@ -176,6 +176,41 @@ class TemplateHelperTest extends UnitTestCase
     /**
      * @test
      */
+    public function getConfValueStringWithoutContentObjectReturnsSetValue(): void
+    {
+        $subject = new TestingTemplateHelper([]);
+        $subject->cObj = null;
+
+        $key = 'test';
+        $value = 'This is a test.';
+        $subject->setConfigurationValue($key, $value);
+
+        $result = $subject->getConfValueString($key);
+
+        self::assertSame($value, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getConfValueStringWithoutFrontEndReturnsSetValue(): void
+    {
+        unset($GLOBALS['TSFE']);
+
+        $subject = new TestingTemplateHelper([]);
+
+        $key = 'test';
+        $value = 'This is a test.';
+        $subject->setConfigurationValue($key, $value);
+
+        $result = $subject->getConfValueString($key);
+
+        self::assertSame($value, $result);
+    }
+
+    /**
+     * @test
+     */
     public function getConfValueIntegerCastsStringToInt(): void
     {
         $this->subject->setConfigurationValue('test', '42');


### PR DESCRIPTION
This mostly affects unit tests with a minimal setup in other extensions.