### PR TITLE
[TASK] Move PHPCov to PHIVE

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore
+/.phive/ export-ignore
 /.php_cs.dist export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /Configuration/php-cs-fixer.php export-ignore
@@ -13,3 +14,4 @@
 /phpstan-baseline.neon export-ignore
 /phpstan.neon export-ignore
 /rector.php export-ignore
+/tools/ export-ignore binary

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -18,7 +18,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           coverage: xdebug
           extensions: xdebug, mysqli
-          tools: composer:v2.3
+          tools: composer:v2.3,phive
       - name: "Show Composer version"
         run: composer --version
       - name: "Cache dependencies installed with composer"
@@ -43,6 +43,8 @@ jobs:
         run: |
           composer update --no-ansi --no-interaction --no-progress --with-dependencies
           composer show
+      - name: "Install the PHIVE-installed tools"
+        run: "phive install --trust-gpg-keys D8406D0D82947747293778314AA394086372C20A"
       - name: "Start MySQL"
         run: "sudo /etc/init.d/mysql start"
       - name: "Run unit tests with coverage"

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /.php_cs.cache
 /composer.lock
 /nbproject
+/tools
 /var/

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="phpcov" version="^8.2.1" installed="8.2.1" location="./tools/phpcov" copy="false"/>
+</phive>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Move PHPCov to PHIVE (#943)
 - Improve the type annotations (#941, #942)
 - Make the usage of types more strict (#940)
 

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
 		"phpstan/phpstan": "^1.6.3",
 		"phpstan/phpstan-phpunit": "^1.1.1",
 		"phpstan/phpstan-strict-rules": "^1.2.2",
-		"phpunit/phpcov": "^6.0.1",
 		"phpunit/phpunit": "^8.5.25",
 		"saschaegerer/phpstan-typo3": "^1.1.2",
 		"sjbr/static-info-tables": "^6.9.6",
@@ -108,7 +107,7 @@
 		],
 		"ci:coverage:merge": [
 			"@coverage:create-directories",
-			".Build/vendor/bin/phpcov merge --clover=./build/logs/clover.xml ./.Build/coverage/"
+			"tools/phpcov merge --clover=./build/logs/clover.xml ./.Build/coverage/"
 		],
 		"ci:coverage:unit": [
 			"@coverage:create-directories",
@@ -150,8 +149,10 @@
 		"prepare-release": [
 			"rm -rf .Build",
 			"rm -rf .github",
+			"rm -rf .phive",
 			"rm -rf TestExtensions",
 			"rm -rf Tests",
+			"rm -rf tools",
 			"rm .editorconfig",
 			"rm .gitattributes",
 			"rm .gitignore",


### PR DESCRIPTION
This avoids problems with `composer install` with the current PHP
version span we support.