### PR TITLE
[TASK] Stop testing that the fake FE has `sys_page`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Avoid some version-specific tests (#964)
 - Avoid deprecated `settingLanguage` calls (#955)
 - Build a more complete fake frontend (#954)
 - Use proper mocking with 11LTS in the storage-related tests (#951)

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -21,7 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
-use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
  * @covers \OliverKlee\Oelib\Testing\TestingFramework
@@ -2551,31 +2550,6 @@ final class TestingFrameworkTest extends FunctionalTestCase
         $this->subject->createFrontEndPage();
 
         self::assertSame(0, $this->subject->createFakeFrontEnd());
-    }
-
-    /**
-     * @test
-     */
-    public function createFakeFrontEndWithPageUidCreatesSysPage(): void
-    {
-        $pageUid = $this->subject->createFrontEndPage();
-        $this->subject->createFakeFrontEnd($pageUid);
-
-        /** @var PageRepository|string $page */
-        $page = $this->getFrontEndController()->sys_page;
-        self::assertInstanceOf(PageRepository::class, $page);
-    }
-
-    /**
-     * @test
-     */
-    public function createFakeFrontEndWithoutPageUidDoesNotCreateSysPage(): void
-    {
-        $this->subject->createFakeFrontEnd();
-
-        /** @var PageRepository|string $page */
-        $page = $this->getFrontEndController()->sys_page;
-        self::assertSame('', $page);
     }
 
     /**


### PR DESCRIPTION
This check is not really relevant, and it is version-specific. So
let's remove it.

Fixes #957