### PR TITLE
[TASK] Stop testing the result of `getIndpEnv` for `PATH_INFO`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- Avoid some version-specific tests (#964)
+- Avoid some version-specific tests (#964, #967)
 - Avoid deprecated `settingLanguage` calls (#955)
 - Build a more complete fake frontend (#954)
 - Use proper mocking with 11LTS in the storage-related tests (#951)

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -2709,7 +2709,6 @@ final class TestingFrameworkTest extends FunctionalTestCase
             'HTTP_HOST' => ['HTTP_HOST', 'typo3-test.dev'],
             'TYPO3_HOST_ONLY' => ['TYPO3_HOST_ONLY', 'typo3-test.dev'],
             'TYPO3_PORT' => ['TYPO3_PORT', ''],
-            'PATH_INFO' => ['PATH_INFO', null],
             'QUERY_STRING' => ['QUERY_STRING', ''],
             'HTTP_REFERER' => ['HTTP_REFERER', 'http://typo3-test.dev/'],
             'TYPO3_REQUEST_HOST' => ['TYPO3_REQUEST_HOST', 'http://typo3-test.dev'],


### PR DESCRIPTION
The result is version-specific and unrelated to our code anyway.

Fixes #959