### PR TITLE
[BUGFIX] Properly quote version numbers in the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.2
-          - 7.3
-          - 7.4
-          - 8.0
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-20.04
@@ -65,7 +65,7 @@ jobs:
           - "php:sniff"
           - "php:stan"
         php-version:
-          - 7.4
+          - "7.4"
   unit-tests:
     name: "Unit tests"
     runs-on: ubuntu-20.04
@@ -112,29 +112,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^9.5
-            php-version: 7.2
+          - typo3-version: "^9.5"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^9.5
-            php-version: 7.2
+          - typo3-version: "^9.5"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.3
+          - typo3-version: "^9.5"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.4
+          - typo3-version: "^9.5"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: highest
   functional-tests:
     name: "Functional tests"
@@ -189,27 +189,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^9.5
-            php-version: 7.2
+          - typo3-version: "^9.5"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^9.5
-            php-version: 7.2
+          - typo3-version: "^9.5"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.3
+          - typo3-version: "^9.5"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.4
+          - typo3-version: "^9.5"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: highest

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -66,6 +66,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: highest


### PR DESCRIPTION
This avoids version numbers like 8.0 getting rounded to 8.