### PR TITLE
[CLEANUP] Drop redundant property type annotations for mappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Avoid crashes in `Collection` in PHP 8.1 (#946)
 - Avoid invalid array accesses in the view helpers (#944)
 - Move PHPCov to PHIVE (#943, #948)
-- Improve the type annotations (#941, #942, #995, #1001, #1005)
+- Improve the type annotations (#941, #942, #995, #1001, #1005, #1016)
 - Make the usage of types more strict (#940)
 
 ## 4.1.6

--- a/Classes/Mapper/AbstractDataMapper.php
+++ b/Classes/Mapper/AbstractDataMapper.php
@@ -59,7 +59,7 @@ abstract class AbstractDataMapper
     protected $relations = [];
 
     /**
-     * @var array<int, string> the column names of additional string keys
+     * @var array<int, non-empty-string> the column names of additional string keys
      */
     protected $additionalKeys = [];
 
@@ -67,7 +67,7 @@ abstract class AbstractDataMapper
      * The column names of an additional compound key.
      * There can only be one compound key per data mapper.
      *
-     * @var string[]
+     * @var non-empty-string[]
      */
     protected $compoundKeyParts = [];
 

--- a/Classes/Mapper/BackEndUserGroupMapper.php
+++ b/Classes/Mapper/BackEndUserGroupMapper.php
@@ -11,20 +11,10 @@ use OliverKlee\Oelib\Model\BackEndUserGroup;
  */
 class BackEndUserGroupMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'be_groups';
 
-    /**
-     * @var class-string<BackEndUserGroup> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = BackEndUserGroup::class;
 
-    /**
-     * @var array<non-empty-string, class-string>
-     *      the (possible) relations of the created models in the format DB column name => mapper name
-     */
     protected $relations = [
         'subgroup' => BackEndUserGroupMapper::class,
     ];

--- a/Classes/Mapper/BackEndUserMapper.php
+++ b/Classes/Mapper/BackEndUserMapper.php
@@ -12,27 +12,14 @@ use OliverKlee\Oelib\Model\BackEndUser;
  */
 class BackEndUserMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'be_users';
 
-    /**
-     * @var class-string<BackEndUser> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = BackEndUser::class;
 
-    /**
-     * @var array<non-empty-string, class-string>
-     *      the (possible) relations of the created models in the format DB column name => mapper name
-     */
     protected $relations = [
         'usergroup' => BackEndUserGroupMapper::class,
     ];
 
-    /**
-     * @var array<int, string> the column names of additional string keys
-     */
     protected $additionalKeys = ['username'];
 
     /**

--- a/Classes/Mapper/CountryMapper.php
+++ b/Classes/Mapper/CountryMapper.php
@@ -12,19 +12,10 @@ use OliverKlee\Oelib\Model\Country;
  */
 class CountryMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'static_countries';
 
-    /**
-     * @var class-string<Country> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = Country::class;
 
-    /**
-     * @var array<int, string> the column names of additional string keys
-     */
     protected $additionalKeys = ['cn_iso_2', 'cn_iso_3'];
 
     /**

--- a/Classes/Mapper/CurrencyMapper.php
+++ b/Classes/Mapper/CurrencyMapper.php
@@ -12,27 +12,16 @@ use OliverKlee\Oelib\Model\Currency;
  */
 class CurrencyMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'static_currencies';
 
-    /**
-     * @var class-string<Currency> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = Currency::class;
 
-    /**
-     * @var array<int, string> the column names of additional string keys
-     */
     protected $additionalKeys = ['cu_iso_3'];
 
     /**
      * Finds a language by its ISO 4217 alpha-3 code.
      *
      * @param non-empty-string $isoAlpha3Code the ISO 4217 alpha-3 code to find
-     *
-     * @return Currency the currency
      *
      * @throws NotFoundException if there is no record with the provided ISO 4217 alpha-3 code
      */

--- a/Classes/Mapper/FederalStateMapper.php
+++ b/Classes/Mapper/FederalStateMapper.php
@@ -11,19 +11,10 @@ use OliverKlee\Oelib\Model\FederalState;
  */
 class FederalStateMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string
-     */
     protected $tableName = 'static_country_zones';
 
-    /**
-     * @var class-string<FederalState>
-     */
     protected $modelClassName = FederalState::class;
 
-    /**
-     * @var string[] the column names of additional combined keys
-     */
     protected $compoundKeyParts = ['zn_country_iso_2', 'zn_code'];
 
     /**

--- a/Classes/Mapper/FrontEndUserGroupMapper.php
+++ b/Classes/Mapper/FrontEndUserGroupMapper.php
@@ -11,13 +11,7 @@ use OliverKlee\Oelib\Model\FrontEndUserGroup;
  */
 class FrontEndUserGroupMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'fe_groups';
 
-    /**
-     * @var class-string<FrontEndUserGroup> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = FrontEndUserGroup::class;
 }

--- a/Classes/Mapper/FrontEndUserMapper.php
+++ b/Classes/Mapper/FrontEndUserMapper.php
@@ -15,27 +15,14 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class FrontEndUserMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'fe_users';
 
-    /**
-     * @var class-string<FrontEndUser> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = FrontEndUser::class;
 
-    /**
-     * @var array<non-empty-string, class-string>
-     *      the (possible) relations of the created models in the format DB column name => mapper name
-     */
     protected $relations = [
         'usergroup' => FrontEndUserGroupMapper::class,
     ];
 
-    /**
-     * @var array<int, string> the column names of additional string keys
-     */
     protected $additionalKeys = ['username'];
 
     /**

--- a/Classes/Mapper/LanguageMapper.php
+++ b/Classes/Mapper/LanguageMapper.php
@@ -12,19 +12,10 @@ use OliverKlee\Oelib\Model\Language;
  */
 class LanguageMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'static_languages';
 
-    /**
-     * @var class-string<Language> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = Language::class;
 
-    /**
-     * @var array<int, string> the column names of additional string keys
-     */
     protected $additionalKeys = ['lg_iso_2'];
 
     /**

--- a/Tests/Unit/Mapper/Fixtures/ColumnLessTestingMapper.php
+++ b/Tests/Unit/Mapper/Fixtures/ColumnLessTestingMapper.php
@@ -14,21 +14,10 @@ use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\TestingModel;
  */
 class ColumnLessTestingMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'tx_oelib_test';
 
-    /**
-     * @var non-empty-string a comma-separated list of DB column names to retrieve or "*" for all columns,
-     *      must not be empty
-     *
-     * @phpstan-ignore-next-line We are explicitly testing for a contract violation here.
-     */
+    // @phpstan-ignore-next-line We are explicitly testing for a contract violation here.
     protected $columns = '';
 
-    /**
-     * @var class-string<TestingModel> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = TestingModel::class;
 }

--- a/Tests/Unit/Mapper/Fixtures/ModelLessTestingMapper.php
+++ b/Tests/Unit/Mapper/Fixtures/ModelLessTestingMapper.php
@@ -13,8 +13,5 @@ use OliverKlee\Oelib\Mapper\AbstractDataMapper;
  */
 class ModelLessTestingMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'tx_oelib_test';
 }

--- a/Tests/Unit/Mapper/Fixtures/TableLessTestingMapper.php
+++ b/Tests/Unit/Mapper/Fixtures/TableLessTestingMapper.php
@@ -14,8 +14,5 @@ use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\TestingModel;
  */
 class TableLessTestingMapper extends AbstractDataMapper
 {
-    /**
-     * @var class-string<TestingModel> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = TestingModel::class;
 }

--- a/Tests/Unit/Mapper/Fixtures/TestingChildMapper.php
+++ b/Tests/Unit/Mapper/Fixtures/TestingChildMapper.php
@@ -14,20 +14,10 @@ use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\TestingChildModel;
  */
 class TestingChildMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'tx_oelib_testchild';
 
-    /**
-     * @var class-string<TestingChildModel> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = TestingChildModel::class;
 
-    /**
-     * @var array<non-empty-string, class-string>
-     *      the (possible) relations of the created models in the format DB column name => mapper name
-     */
     protected $relations = [
         'parent' => TestingMapper::class,
         'tx_oelib_parent2' => TestingMapper::class,

--- a/Tests/Unit/Mapper/Fixtures/TestingMapper.php
+++ b/Tests/Unit/Mapper/Fixtures/TestingMapper.php
@@ -18,20 +18,10 @@ use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\TestingModel;
  */
 class TestingMapper extends AbstractDataMapper
 {
-    /**
-     * @var non-empty-string the name of the database table for this mapper
-     */
     protected $tableName = 'tx_oelib_test';
 
-    /**
-     * @var class-string<TestingModel> the model class name for this mapper, must not be empty
-     */
     protected $modelClassName = TestingModel::class;
 
-    /**
-     * @var array<non-empty-string, class-string>
-     *      the (possible) relations of the created models in the format DB column name => mapper name
-     */
     protected $relations = [
         'friend' => TestingMapper::class,
         'owner' => FrontEndUserMapper::class,
@@ -43,14 +33,8 @@ class TestingMapper extends AbstractDataMapper
         'bidirectional' => TestingMapper::class,
     ];
 
-    /**
-     * @var array<int, string> the column names of additional string keys
-     */
     protected $additionalKeys = ['title'];
 
-    /**
-     * @var string[] the column names of an additional compound key
-     */
     protected $compoundKeyParts = ['title', 'header'];
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,17 +31,17 @@ parameters:
 			path: Classes/Mapper/AbstractDataMapper.php
 
 		-
-			message: "#^PHPDoc type array\\<non\\-empty\\-string, class\\-string\\> of property OliverKlee\\\\Oelib\\\\Mapper\\\\BackEndUserGroupMapper\\:\\:\\$relations is not the same as PHPDoc type array\\<non\\-empty\\-string, class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\> of overridden property OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\BackEndUserGroup\\>\\:\\:\\$relations\\.$#"
+			message: "#^Property OliverKlee\\\\Oelib\\\\Mapper\\\\BackEndUserGroupMapper\\:\\:\\$relations \\(array\\<non\\-empty\\-string, class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\>\\) does not accept default value of type array\\{subgroup\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Mapper\\\\\\\\BackEndUserGroupMapper'\\}\\.$#"
 			count: 1
 			path: Classes/Mapper/BackEndUserGroupMapper.php
 
 		-
-			message: "#^PHPDoc type array\\<non\\-empty\\-string, class\\-string\\> of property OliverKlee\\\\Oelib\\\\Mapper\\\\BackEndUserMapper\\:\\:\\$relations is not the same as PHPDoc type array\\<non\\-empty\\-string, class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\> of overridden property OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\BackEndUser\\>\\:\\:\\$relations\\.$#"
+			message: "#^Property OliverKlee\\\\Oelib\\\\Mapper\\\\BackEndUserMapper\\:\\:\\$relations \\(array\\<non\\-empty\\-string, class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\>\\) does not accept default value of type array\\{usergroup\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Mapper\\\\\\\\BackEndUserGroupMapper'\\}\\.$#"
 			count: 1
 			path: Classes/Mapper/BackEndUserMapper.php
 
 		-
-			message: "#^PHPDoc type array\\<non\\-empty\\-string, class\\-string\\> of property OliverKlee\\\\Oelib\\\\Mapper\\\\FrontEndUserMapper\\:\\:\\$relations is not the same as PHPDoc type array\\<non\\-empty\\-string, class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\> of overridden property OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\FrontEndUser\\>\\:\\:\\$relations\\.$#"
+			message: "#^Property OliverKlee\\\\Oelib\\\\Mapper\\\\FrontEndUserMapper\\:\\:\\$relations \\(array\\<non\\-empty\\-string, class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\>\\) does not accept default value of type array\\{usergroup\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Mapper\\\\\\\\FrontEndUserGroupMapper'\\}\\.$#"
 			count: 1
 			path: Classes/Mapper/FrontEndUserMapper.php
 
@@ -236,12 +236,12 @@ parameters:
 			path: Tests/Functional/ViewHelpers/PriceViewHelperTest.php
 
 		-
-			message: "#^PHPDoc type array\\<non\\-empty\\-string, class\\-string\\> of property OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Mapper\\\\Fixtures\\\\TestingChildMapper\\:\\:\\$relations is not the same as PHPDoc type array\\<non\\-empty\\-string, class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\> of overridden property OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Model\\\\Fixtures\\\\TestingChildModel\\>\\:\\:\\$relations\\.$#"
+			message: "#^Property OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Mapper\\\\Fixtures\\\\TestingChildMapper\\:\\:\\$relations \\(array\\<non\\-empty\\-string, class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\>\\) does not accept default value of type array\\{parent\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Tests\\\\\\\\Unit\\\\\\\\Mapper\\\\\\\\Fixtures\\\\\\\\TestingMapper', tx_oelib_parent2\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Tests\\\\\\\\Unit\\\\\\\\Mapper\\\\\\\\Fixtures\\\\\\\\TestingMapper', tx_oelib_parent3\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Tests\\\\\\\\Unit\\\\\\\\Mapper\\\\\\\\Fixtures\\\\\\\\TestingMapper'\\}\\.$#"
 			count: 1
 			path: Tests/Unit/Mapper/Fixtures/TestingChildMapper.php
 
 		-
-			message: "#^PHPDoc type array\\<non\\-empty\\-string, class\\-string\\> of property OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Mapper\\\\Fixtures\\\\TestingMapper\\:\\:\\$relations is not the same as PHPDoc type array\\<non\\-empty\\-string, class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\> of overridden property OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Model\\\\Fixtures\\\\TestingModel\\>\\:\\:\\$relations\\.$#"
+			message: "#^Property OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Mapper\\\\Fixtures\\\\TestingMapper\\:\\:\\$relations \\(array\\<non\\-empty\\-string, class\\-string\\<OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\>\\>\\) does not accept default value of type array\\{friend\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Tests\\\\\\\\Unit\\\\\\\\Mapper\\\\\\\\Fixtures\\\\\\\\TestingMapper', owner\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Mapper\\\\\\\\FrontEndUserMapper', children\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Tests\\\\\\\\Unit\\\\\\\\Mapper\\\\\\\\Fixtures\\\\\\\\TestingMapper', related_records\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Tests\\\\\\\\Unit\\\\\\\\Mapper\\\\\\\\Fixtures\\\\\\\\TestingMapper', composition\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Tests\\\\\\\\Unit\\\\\\\\Mapper\\\\\\\\Fixtures\\\\\\\\TestingChildMapper', composition2\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Tests\\\\\\\\Unit\\\\\\\\Mapper\\\\\\\\Fixtures\\\\\\\\TestingChildMapper', composition_without_sorting\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Tests\\\\\\\\Unit\\\\\\\\Mapper\\\\\\\\Fixtures\\\\\\\\TestingChildMapper', bidirectional\\: 'OliverKlee\\\\\\\\Oelib\\\\\\\\Tests\\\\\\\\Unit\\\\\\\\Mapper\\\\\\\\Fixtures\\\\\\\\TestingMapper'\\}\\.$#"
 			count: 1
 			path: Tests/Unit/Mapper/Fixtures/TestingMapper.php
 


### PR DESCRIPTION
Also make some type annotations more specific.

Fixes #1004