### PR TITLE
[BUGFIX] Properly check for falsey configuration values

### DIFF
--- a/Classes/Templating/TemplateHelper.php
+++ b/Classes/Templating/TemplateHelper.php
@@ -23,6 +23,11 @@ class TemplateHelper extends SalutationSwitcher
     private const LABEL_PATTERN = '/###(LABEL_([A-Z\\d_]+))###/';
 
     /**
+     * @var array<int, null|false|''|0|'0'>
+     */
+    private const FALSEY_VALUES = [null, false, '', 0, '0'];
+
+    /**
      * @var string the prefix used for CSS classes
      */
     public $prefixId = '';
@@ -161,7 +166,8 @@ class TemplateHelper extends SalutationSwitcher
             $flexFormsValue = $this->addPathToFileName($flexFormsValue);
         }
 
-        return $flexFormsValue ?? $configurationValueFromTypoScript;
+        return !\in_array($flexFormsValue, self::FALSEY_VALUES, true)
+            ? $flexFormsValue : $configurationValueFromTypoScript;
     }
 
     /**


### PR DESCRIPTION
After some code cleanup gone bad, `TemplateHelper::getConfValue`
failed to fall back to the value from TypoScript if the value
from the flexforms was an empty string or zero.

This fixes a crash in the seminars list view due to the HTML template
not getting loaded anymore.

Fixes #1034