### PR TITLE
[BUGFIX] Explicitly require Prophecy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
 		"oliverklee/user-oelibtest": "@dev",
 		"oliverklee/user-oelibtest2": "@dev",
 		"php-coveralls/php-coveralls": "^2.5.2",
+		"phpspec/prophecy": "^1.15.0",
 		"phpstan/extension-installer": "^1.1.0",
 		"phpstan/phpstan": "^1.8.2",
 		"phpstan/phpstan-phpunit": "^1.1.1",


### PR DESCRIPTION
PHPUnit has dropped its dependency on Prophecy. In order to keep using
Prophecy in our tests, we need to add it as an explicit (development)
dependency.

Also, relying on transitive dependencies is bad practice anyway.