### PR TITLE
[BUGFIX] Bump the minimal 10.4 Extbase requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## 4.1.8
 
 ### Fixed
+- Bump the minimal 10.4 Extbase requirement (#1044)
 - Properly check for falsey configuration values (#1035)
 
 ## 4.1.7

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"doctrine/dbal": "^2.10",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",
 		"typo3/cms-core": "^9.5.16 || ^10.4.1",
-		"typo3/cms-extbase": "^9.5 || ^10.4",
+		"typo3/cms-extbase": "^9.5 || ^10.4.6",
 		"typo3/cms-fluid": "^9.5 || ^10.4",
 		"typo3/cms-frontend": "^9.5 || ^10.4",
 		"typo3fluid/fluid": "^2.6.10"


### PR DESCRIPTION
Extbase < 10.4.6 has a bug that causes it to stumble over PHPDoc
annotations in the repository.