### PR TITLE
[BUGFIX] Adapt the configuration check advice to the backend structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- Add missing linebreak in the configuration check message (#1061)
+- Improve the configuration check messages (#1061, #1062)
 
 ## 4.1.9
 

--- a/Classes/Configuration/AbstractConfigurationCheck.php
+++ b/Classes/Configuration/AbstractConfigurationCheck.php
@@ -151,7 +151,8 @@ abstract class AbstractConfigurationCheck
     {
         $this->warnings[] = '<div lang="en" class="alert alert-warning mt-3" role="alert">' .
             $rawWarningText . '<br/>' .
-            '<i>The configuration check for this extension can be disabled in the extension manager.</i>' .
+            'The configuration check for this extension can be disabled in the extension settings in the backend:
+            <i>Admin Tools &gt; Settings &gt; Extension Configuration</i>' .
             '</div>';
     }
 

--- a/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
@@ -236,9 +236,14 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
         $subject->generateWarningWithText($warningText);
 
         $warnings = $subject->getWarningsAsHtml();
+        $firstWarning = $warnings[0];
         self::assertStringContainsString(
-            'The configuration check for this extension can be disabled in the extension manager.',
-            $warnings[0]
+            'The configuration check for this extension can be disabled in the extension settings in the backend:',
+            $firstWarning
+        );
+        self::assertStringContainsString(
+            '<i>Admin Tools &gt; Settings &gt; Extension Configuration</i>',
+            $firstWarning
         );
     }
 


### PR DESCRIPTION
With TYPO3 9LTS and higher, the extension settings are no longer part of the extension manager, but now are located within the Settings module.