### PR TITLE
[TASK] Require typo3/cms-core instead of typo3/minimal on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         env:
           TYPO3: "${{ matrix.typo3-version }}"
         run: |
-          composer require --no-ansi --no-interaction --no-progress --no-install typo3/minimal:"$TYPO3"
+          composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"$TYPO3"
           composer show
       - name: "Install lowest dependencies with composer"
         if: "matrix.composer-dependencies == 'lowest'"
@@ -164,7 +164,7 @@ jobs:
         env:
           TYPO3: "${{ matrix.typo3-version }}"
         run: |
-          composer require --no-ansi --no-interaction --no-progress --no-install typo3/minimal:"$TYPO3"
+          composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"$TYPO3"
           composer show
       - name: "Install lowest dependencies with composer"
         if: "matrix.composer-dependencies == 'lowest'"

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           TYPO3: "${{ matrix.typo3-version }}"
         run: |
-          composer require --no-ansi --no-interaction --no-progress --no-install typo3/minimal:"$TYPO3"
+          composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"$TYPO3"
           composer show
       - name: "Install lowest dependencies with composer"
         if: "matrix.composer-dependencies == 'lowest'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Improve the configuration check messages (#1061, #1062, #1063)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-- Improve the configuration check messages (#1061, #1062, #1063)
 
 ## 4.1.9
 


### PR DESCRIPTION
This unblocks using the development version of TYPO3.

Fixes #1053