### PR TITLE
[TASK] Deprecate the visibility-related `Node` and `Tree`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Improve the configuration check messages (#1061, #1062, #1063)
 
 ### Deprecated
+- Deprecate the visibility-related `Node` and `Tree` (#1068)
 
 ### Removed
 

--- a/Classes/Visibility/Node.php
+++ b/Classes/Visibility/Node.php
@@ -6,6 +6,8 @@ namespace OliverKlee\Oelib\Visibility;
 
 /**
  * This class represents a node for a visibility tree.
+ *
+ * @deprecated will be removed in oelib 5.0
  */
 class Node
 {

--- a/Classes/Visibility/Tree.php
+++ b/Classes/Visibility/Tree.php
@@ -8,6 +8,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * This class represents a visibility tree.
+ *
+ * @deprecated will be removed in oelib 5.0
  */
 class Tree
 {


### PR DESCRIPTION
Those classes are not used anymore.

Fixes #561