### PR TITLE
[BUGFIX] Use the `TYPO3` constant instead of `TYPO3_MODE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for TYPO3 9LTS (#1094)
 
 ### Fixed
+- Use the `TYPO3` constant instead of `TYPO3_MODE` (#1098)
 
 ## 4.3.0
 

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
     'fe_users',

--- a/Configuration/TCA/tx_oelib_domain_model_germanzipcode.php
+++ b/Configuration/TCA/tx_oelib_domain_model_germanzipcode.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 $labelPrefix = 'LLL:EXT:oelib/Resources/Private/Language/locallang_db.xlf:tx_oelib_domain_model_germanzipcode';
 return [

--- a/Configuration/TCA/tx_oelib_test.php
+++ b/Configuration/TCA/tx_oelib_test.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 return [
     'ctrl' => [

--- a/Configuration/TCA/tx_oelib_testchild.php
+++ b/Configuration/TCA/tx_oelib_testchild.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 return [
     'ctrl' => [

--- a/TestExtensions/user_oelibtest/Configuration/TCA/user_oelibtest_test.php
+++ b/TestExtensions/user_oelibtest/Configuration/TCA/user_oelibtest_test.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 return [
     'ctrl' => [

--- a/TestExtensions/user_oelibtest2/Configuration/TCA/user_oelibtest2_test.php
+++ b/TestExtensions/user_oelibtest2/Configuration/TCA/user_oelibtest2_test.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 return [
     'ctrl' => [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['oelib']['testingFrameworkCleanUp'][]
     = \OliverKlee\Oelib\Testing\TestingFrameworkCleanup::class;


### PR DESCRIPTION
Fixes #1052