### PR TITLE
[TASK] Drop the `mikey179/vfsstream` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
 		"ergebnis/composer-normalize": "^2.19.0",
 		"friendsofphp/php-cs-fixer": "^3.4.0",
 		"jangregor/phpstan-prophecy": "^1.0.0",
-		"mikey179/vfsstream": "^1.6.11",
 		"nimut/testing-framework": "^6.0.1",
 		"oliverklee/user-oelibtest": "@dev",
 		"oliverklee/user-oelibtest2": "@dev",


### PR DESCRIPTION
We're not using this package here anymore.