### PR TITLE
[BUGFIX] Stop using the deprecated `ObjectManager` in 11LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 - Add support for PHP 8.1 (#1127)
-- Add support for TYPO3 11LTS (#1114, #1115, #1123, #1131, #1136)
+- Add support for TYPO3 11LTS (#1114, #1115, #1123, #1126, #1131, #1136)
 - Add a `ConvertableToMimeAddress` interface and trait (#1092)
 
 ### Changed

--- a/Tests/Functional/Domain/Repository/GermanZipCodeRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/GermanZipCodeRepositoryTest.php
@@ -7,12 +7,14 @@ namespace OliverKlee\Oelib\Tests\Functional\Domain\Repository;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use OliverKlee\Oelib\Domain\Model\GermanZipCode;
 use OliverKlee\Oelib\Domain\Repository\GermanZipCodeRepository;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * @covers \OliverKlee\Oelib\Domain\Model\GermanZipCode
  * @covers \OliverKlee\Oelib\Domain\Repository\GermanZipCodeRepository
+ * @covers \OliverKlee\Oelib\Domain\Repository\Traits\StoragePageAgnostic
  */
 final class GermanZipCodeRepositoryTest extends FunctionalTestCase
 {
@@ -27,7 +29,13 @@ final class GermanZipCodeRepositoryTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->subject = GeneralUtility::makeInstance(ObjectManager::class)->get(GermanZipCodeRepository::class);
+        if ((new Typo3Version())->getMajorVersion() >= 11) {
+            $this->subject = GeneralUtility::makeInstance(GermanZipCodeRepository::class);
+        } else {
+            $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+            $this->subject = $objectManager->get(GermanZipCodeRepository::class);
+        }
+
         $this->importDataSet(__DIR__ . '/Fixtures/ZipCodes.xml');
     }
 


### PR DESCRIPTION
Fixes #987