### PR TITLE
[TASK] Always call `parent::setUp()` in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add a `ConvertableToMimeAddress` interface and trait (#1092)
 
 ### Changed
+- Switch to the TYPO3 testing framework (#1130)
 
 ### Deprecated
 

--- a/Tests/Unit/Authentication/BackEndLoginManagerTest.php
+++ b/Tests/Unit/Authentication/BackEndLoginManagerTest.php
@@ -20,6 +20,8 @@ final class BackEndLoginManagerTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = BackEndLoginManager::getInstance();
     }
 

--- a/Tests/Unit/Authentication/FrontEndLoginManagerTest.php
+++ b/Tests/Unit/Authentication/FrontEndLoginManagerTest.php
@@ -20,6 +20,8 @@ final class FrontEndLoginManagerTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = FrontEndLoginManager::getInstance();
     }
 

--- a/Tests/Unit/Configuration/ConfigurationProxyTest.php
+++ b/Tests/Unit/Configuration/ConfigurationProxyTest.php
@@ -35,6 +35,8 @@ final class ConfigurationProxyTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         /** @var ConfigurationProxy $subject */
         $subject = ConfigurationProxy::getInstance('oelib');
         // ensures the same configuration at the beginning of each test

--- a/Tests/Unit/Configuration/DummyConfigurationTest.php
+++ b/Tests/Unit/Configuration/DummyConfigurationTest.php
@@ -21,6 +21,8 @@ final class DummyConfigurationTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new DummyConfiguration();
     }
 

--- a/Tests/Unit/Configuration/ExtbaseConfigurationTest.php
+++ b/Tests/Unit/Configuration/ExtbaseConfigurationTest.php
@@ -21,6 +21,8 @@ final class ExtbaseConfigurationTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new ExtbaseConfiguration();
     }
 

--- a/Tests/Unit/Configuration/PageFinderTest.php
+++ b/Tests/Unit/Configuration/PageFinderTest.php
@@ -19,6 +19,8 @@ final class PageFinderTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = PageFinder::getInstance();
     }
 

--- a/Tests/Unit/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/Configuration/TypoScriptConfigurationTest.php
@@ -21,6 +21,8 @@ final class TypoScriptConfigurationTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new TypoScriptConfiguration();
     }
 

--- a/Tests/Unit/DataStructures/AbstractObjectWithPublicAccessorsTest.php
+++ b/Tests/Unit/DataStructures/AbstractObjectWithPublicAccessorsTest.php
@@ -20,6 +20,8 @@ final class AbstractObjectWithPublicAccessorsTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new TestingObjectWithPublicAccessors();
     }
 

--- a/Tests/Unit/DataStructures/AbstractReadOnlyObjectWithAccessorsTest.php
+++ b/Tests/Unit/DataStructures/AbstractReadOnlyObjectWithAccessorsTest.php
@@ -20,6 +20,8 @@ final class AbstractReadOnlyObjectWithAccessorsTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new TestingReadOnlyObjectWithPublicAccessors();
     }
 

--- a/Tests/Unit/DataStructures/CollectionTest.php
+++ b/Tests/Unit/DataStructures/CollectionTest.php
@@ -21,6 +21,8 @@ final class CollectionTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         /** @var Collection<TestingModel> $subject */
         $subject = new Collection();
         $this->subject = $subject;

--- a/Tests/Unit/Domain/Model/GermanZipCodeTest.php
+++ b/Tests/Unit/Domain/Model/GermanZipCodeTest.php
@@ -21,6 +21,8 @@ final class GermanZipCodeTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new GermanZipCode();
     }
 

--- a/Tests/Unit/Domain/Model/Traits/CachedAssociationCountTest.php
+++ b/Tests/Unit/Domain/Model/Traits/CachedAssociationCountTest.php
@@ -19,6 +19,8 @@ final class CachedAssociationCountTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new ParentModel();
     }
 

--- a/Tests/Unit/Domain/Model/Traits/ChangeDateTest.php
+++ b/Tests/Unit/Domain/Model/Traits/ChangeDateTest.php
@@ -20,6 +20,8 @@ final class ChangeDateTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new ChangedModel();
     }
 

--- a/Tests/Unit/Domain/Model/Traits/CreationDateTest.php
+++ b/Tests/Unit/Domain/Model/Traits/CreationDateTest.php
@@ -20,6 +20,8 @@ final class CreationDateTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new CreatedModel();
     }
 

--- a/Tests/Unit/Domain/Model/Traits/LazyLoadingPropertiesTest.php
+++ b/Tests/Unit/Domain/Model/Traits/LazyLoadingPropertiesTest.php
@@ -19,6 +19,8 @@ final class LazyLoadingPropertiesTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new LazyLoadingModel();
     }
 

--- a/Tests/Unit/Domain/Repository/GermanZipCodeRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/GermanZipCodeRepositoryTest.php
@@ -22,6 +22,8 @@ final class GermanZipCodeRepositoryTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $objectManagerStub = $this->prophesize(ObjectManagerInterface::class)->reveal();
         $this->subject = new GermanZipCodeRepository($objectManagerStub);
     }

--- a/Tests/Unit/Domain/Repository/PageRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/PageRepositoryTest.php
@@ -20,6 +20,8 @@ final class PageRepositoryTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new PageRepository();
     }
 

--- a/Tests/Unit/Domain/Repository/Traits/DirectPersistTest.php
+++ b/Tests/Unit/Domain/Repository/Traits/DirectPersistTest.php
@@ -25,6 +25,8 @@ final class DirectPersistTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $objectManagerStub = $this->prophesize(ObjectManagerInterface::class)->reveal();
         $this->subject = new DirectPersistRepository($objectManagerStub);
 

--- a/Tests/Unit/Email/SystemEmailFromBuilderTest.php
+++ b/Tests/Unit/Email/SystemEmailFromBuilderTest.php
@@ -20,6 +20,8 @@ final class SystemEmailFromBuilderTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new SystemEmailFromBuilder();
     }
 

--- a/Tests/Unit/Geocoding/DummyGeocodingLookupTest.php
+++ b/Tests/Unit/Geocoding/DummyGeocodingLookupTest.php
@@ -20,6 +20,8 @@ final class DummyGeocodingLookupTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new DummyGeocodingLookup();
     }
 

--- a/Tests/Unit/Geocoding/GeoCalculatorTest.php
+++ b/Tests/Unit/Geocoding/GeoCalculatorTest.php
@@ -29,6 +29,8 @@ final class GeoCalculatorTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new GeoCalculator();
 
         $this->geoObject = new TestingGeo();

--- a/Tests/Unit/Geocoding/GoogleGeocodingTest.php
+++ b/Tests/Unit/Geocoding/GoogleGeocodingTest.php
@@ -28,6 +28,8 @@ final class GoogleGeocodingTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $configurationRegistry = ConfigurationRegistry::getInstance();
         $configurationRegistry->set('plugin', new DummyConfiguration());
         $this->configuration = new DummyConfiguration();

--- a/Tests/Unit/Http/HeaderProxyFactoryTest.php
+++ b/Tests/Unit/Http/HeaderProxyFactoryTest.php
@@ -22,6 +22,8 @@ final class HeaderProxyFactoryTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         // Only the instance with an enabled test mode can be tested as in the
         // non-test mode added headers are not accessible.
         HeaderProxyFactory::getInstance()->enableTestMode();

--- a/Tests/Unit/Logging/Traits/LoggingAwareTest.php
+++ b/Tests/Unit/Logging/Traits/LoggingAwareTest.php
@@ -22,6 +22,8 @@ final class LoggingAwareTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new TestingLoggingAware();
     }
 

--- a/Tests/Unit/Mapper/AbstractDataMapperTest.php
+++ b/Tests/Unit/Mapper/AbstractDataMapperTest.php
@@ -28,6 +28,8 @@ final class AbstractDataMapperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new TestingMapper();
     }
 

--- a/Tests/Unit/Mapper/BackEndUserGroupMapperTest.php
+++ b/Tests/Unit/Mapper/BackEndUserGroupMapperTest.php
@@ -21,6 +21,8 @@ final class BackEndUserGroupMapperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new BackEndUserGroupMapper();
     }
 

--- a/Tests/Unit/Mapper/BackEndUserMapperTest.php
+++ b/Tests/Unit/Mapper/BackEndUserMapperTest.php
@@ -21,6 +21,8 @@ final class BackEndUserMapperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new BackEndUserMapper();
     }
 

--- a/Tests/Unit/Mapper/CountryMapperTest.php
+++ b/Tests/Unit/Mapper/CountryMapperTest.php
@@ -21,6 +21,8 @@ final class CountryMapperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new CountryMapper();
     }
 

--- a/Tests/Unit/Mapper/CurrencyMapperTest.php
+++ b/Tests/Unit/Mapper/CurrencyMapperTest.php
@@ -21,6 +21,8 @@ final class CurrencyMapperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new CurrencyMapper();
     }
 

--- a/Tests/Unit/Mapper/FederalStateMapperTest.php
+++ b/Tests/Unit/Mapper/FederalStateMapperTest.php
@@ -21,6 +21,8 @@ final class FederalStateMapperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new FederalStateMapper();
     }
 

--- a/Tests/Unit/Mapper/FrontEndUserGroupMapperTest.php
+++ b/Tests/Unit/Mapper/FrontEndUserGroupMapperTest.php
@@ -21,6 +21,8 @@ final class FrontEndUserGroupMapperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new FrontEndUserGroupMapper();
     }
 

--- a/Tests/Unit/Mapper/FrontEndUserMapperTest.php
+++ b/Tests/Unit/Mapper/FrontEndUserMapperTest.php
@@ -21,6 +21,8 @@ final class FrontEndUserMapperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new FrontEndUserMapper();
     }
 

--- a/Tests/Unit/Mapper/IdentityMapTest.php
+++ b/Tests/Unit/Mapper/IdentityMapTest.php
@@ -21,6 +21,8 @@ final class IdentityMapTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new IdentityMap();
     }
 

--- a/Tests/Unit/Mapper/LanguageMapperTest.php
+++ b/Tests/Unit/Mapper/LanguageMapperTest.php
@@ -21,6 +21,8 @@ final class LanguageMapperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new LanguageMapper();
     }
 

--- a/Tests/Unit/Model/AbstractModelTest.php
+++ b/Tests/Unit/Model/AbstractModelTest.php
@@ -24,6 +24,8 @@ final class AbstractModelTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $GLOBALS['SIM_EXEC_TIME'] = 1524751343;
 
         $this->subject = new TestingModel();

--- a/Tests/Unit/Model/BackEndUserGroupTest.php
+++ b/Tests/Unit/Model/BackEndUserGroupTest.php
@@ -20,6 +20,8 @@ final class BackEndUserGroupTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new BackEndUserGroup();
     }
 

--- a/Tests/Unit/Model/BackEndUserTest.php
+++ b/Tests/Unit/Model/BackEndUserTest.php
@@ -24,6 +24,8 @@ final class BackEndUserTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new BackEndUser();
     }
 

--- a/Tests/Unit/Model/CountryTest.php
+++ b/Tests/Unit/Model/CountryTest.php
@@ -19,6 +19,8 @@ final class CountryTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new Country();
     }
 

--- a/Tests/Unit/Model/CurrencyTest.php
+++ b/Tests/Unit/Model/CurrencyTest.php
@@ -19,6 +19,8 @@ final class CurrencyTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new Currency();
     }
 

--- a/Tests/Unit/Model/FederalStateTest.php
+++ b/Tests/Unit/Model/FederalStateTest.php
@@ -19,6 +19,8 @@ final class FederalStateTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new FederalState();
     }
 

--- a/Tests/Unit/Model/FrontEndUserGroupTest.php
+++ b/Tests/Unit/Model/FrontEndUserGroupTest.php
@@ -19,6 +19,8 @@ final class FrontEndUserGroupTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new FrontEndUserGroup();
     }
 

--- a/Tests/Unit/Model/FrontEndUserTest.php
+++ b/Tests/Unit/Model/FrontEndUserTest.php
@@ -36,6 +36,8 @@ final class FrontEndUserTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new FrontEndUser();
 
         $this->globalExecTimeBackup = $GLOBALS['EXEC_TIME'];

--- a/Tests/Unit/Model/LanguageTest.php
+++ b/Tests/Unit/Model/LanguageTest.php
@@ -19,6 +19,8 @@ final class LanguageTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new Language();
     }
 

--- a/Tests/Unit/Session/FakeSessionTest.php
+++ b/Tests/Unit/Session/FakeSessionTest.php
@@ -20,6 +20,8 @@ final class FakeSessionTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new FakeSession();
     }
 

--- a/Tests/Unit/System/Typo3VersionTest.php
+++ b/Tests/Unit/System/Typo3VersionTest.php
@@ -19,6 +19,8 @@ final class Typo3VersionTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->version = new \TYPO3\CMS\Core\Information\Typo3Version();
     }
 

--- a/Tests/Unit/Templating/TemplateHelperTest.php
+++ b/Tests/Unit/Templating/TemplateHelperTest.php
@@ -25,6 +25,8 @@ final class TemplateHelperTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
         $cacheManager->setCacheConfigurations(['l10n' => ['backend' => NullBackend::class]]);
 

--- a/Tests/Unit/Templating/TemplateTest.php
+++ b/Tests/Unit/Templating/TemplateTest.php
@@ -20,6 +20,8 @@ final class TemplateTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new Template();
     }
 

--- a/Tests/Unit/Testing/TestingFrameworkTest.php
+++ b/Tests/Unit/Testing/TestingFrameworkTest.php
@@ -22,6 +22,8 @@ final class TestingFrameworkTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->subject = new TestingFramework('tx_oelib');
     }
 


### PR DESCRIPTION
Part of #809