### PR TITLE
[TASK] Stop using `$this->getDatabaseConnection()` in tests (part 1)

### DIFF
--- a/Tests/Functional/Model/AbstractModelTest.php
+++ b/Tests/Functional/Model/AbstractModelTest.php
@@ -44,14 +44,16 @@ final class AbstractModelTest extends FunctionalTestCase
     }
 
     /**
-     * Creates a test record.
-     *
      * @return int the UID
      */
     private function createTestRecord(): int
     {
-        $this->getDatabaseConnection()->insertArray('tx_oelib_test', ['title' => self::TEST_RECORD_TITLE]);
-        return (int)$this->getDatabaseConnection()->lastInsertId();
+        $connection = $this->getConnectionPool()->getConnectionForTable('tx_oelib_test');
+        $connection->insert(
+            'tx_oelib_test',
+            ['title' => self::TEST_RECORD_TITLE]
+        );
+        return (int)$connection->lastInsertId('tx_oelib_test');
     }
 
     // Tests concerning __clone

--- a/Tests/Functional/Model/FrontEndUserTest.php
+++ b/Tests/Functional/Model/FrontEndUserTest.php
@@ -35,7 +35,8 @@ final class FrontEndUserTest extends FunctionalTestCase
      */
     private function importStaticData(): void
     {
-        if ($this->getDatabaseConnection()->selectCount('*', 'static_countries') === 0) {
+        $connection = $this->getConnectionPool()->getConnectionForTable('static_countries');
+        if ($connection->count('*', 'static_countries', []) === 0) {
             $this->importDataSet(__DIR__ . '/../Fixtures/Countries.xml');
         }
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -641,11 +641,6 @@ parameters:
 			path: Tests/Functional/Mapper/LanguageMapperTest.php
 
 		-
-			message: "#^Casting to int something that's already int\\.$#"
-			count: 1
-			path: Tests/Functional/Model/AbstractModelTest.php
-
-		-
 			message: "#^Property OliverKlee\\\\Oelib\\\\Tests\\\\Functional\\\\Model\\\\AbstractModelTest\\:\\:\\$testExtensionsToLoad type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Tests/Functional/Model/AbstractModelTest.php


### PR DESCRIPTION
This is in preparation for switching to the TYPO3 testing framework.

Part of #1142