### PR TITLE
[TASK] Stop using `$this->getDatabaseConnection()` in tests (part 2)

### DIFF
--- a/Tests/Functional/Mapper/CountryMapperTest.php
+++ b/Tests/Functional/Mapper/CountryMapperTest.php
@@ -37,7 +37,8 @@ final class CountryMapperTest extends FunctionalTestCase
      */
     private function importStaticData(): void
     {
-        if ($this->getDatabaseConnection()->selectCount('*', 'static_countries') === 0) {
+        $connection = $this->getConnectionPool()->getConnectionForTable('static_countries');
+        if ($connection->count('*', 'static_countries', []) === 0) {
             $this->importDataSet(__DIR__ . '/../Fixtures/Countries.xml');
         }
     }

--- a/Tests/Functional/Mapper/CurrencyMapperTest.php
+++ b/Tests/Functional/Mapper/CurrencyMapperTest.php
@@ -38,7 +38,8 @@ final class CurrencyMapperTest extends FunctionalTestCase
      */
     private function importStaticData(): void
     {
-        if ($this->getDatabaseConnection()->selectCount('*', 'static_currencies') === 0) {
+        $connection = $this->getConnectionPool()->getConnectionForTable('static_currencies');
+        if ($connection->count('*', 'static_currencies', []) === 0) {
             $this->importDataSet(__DIR__ . '/../Fixtures/Currencies.xml');
         }
     }

--- a/Tests/Functional/Mapper/FederalStateMapperTest.php
+++ b/Tests/Functional/Mapper/FederalStateMapperTest.php
@@ -37,7 +37,8 @@ final class FederalStateMapperTest extends FunctionalTestCase
      */
     private function importStaticData(): void
     {
-        if ($this->getDatabaseConnection()->selectCount('*', 'static_country_zones') === 0) {
+        $connection = $this->getConnectionPool()->getConnectionForTable('static_country_zones');
+        if ($connection->count('*', 'static_country_zones', []) === 0) {
             $this->importDataSet(__DIR__ . '/../Fixtures/CountryZones.xml');
         }
     }

--- a/Tests/Functional/Mapper/LanguageMapperTest.php
+++ b/Tests/Functional/Mapper/LanguageMapperTest.php
@@ -36,7 +36,8 @@ final class LanguageMapperTest extends FunctionalTestCase
      */
     private function importStaticData(): void
     {
-        if ($this->getDatabaseConnection()->selectCount('*', 'static_languages') === 0) {
+        $connection = $this->getConnectionPool()->getConnectionForTable('static_languages');
+        if ($connection->count('*', 'static_languages', []) === 0) {
             $this->importDataSet(__DIR__ . '/../Fixtures/Languages.xml');
         }
     }

--- a/Tests/Functional/Model/AbstractModelTest.php
+++ b/Tests/Functional/Model/AbstractModelTest.php
@@ -49,10 +49,7 @@ final class AbstractModelTest extends FunctionalTestCase
     private function createTestRecord(): int
     {
         $connection = $this->getConnectionPool()->getConnectionForTable('tx_oelib_test');
-        $connection->insert(
-            'tx_oelib_test',
-            ['title' => self::TEST_RECORD_TITLE]
-        );
+        $connection->insert('tx_oelib_test', ['title' => self::TEST_RECORD_TITLE]);
         return (int)$connection->lastInsertId('tx_oelib_test');
     }
 


### PR DESCRIPTION
This is in preparation for switching to the TYPO3 testing framework.

Part of #1142