### PR TITLE
[TASK] Only work on the auto increment value if the DB supports it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for TYPO3 9LTS (#1094)
 
 ### Fixed
+- Only work on the auto increment value if the DB supports it (#1166)
 - Drop obsolete Doctrine DBAL calls (#1112)
 - Use the `TYPO3` constant instead of `TYPO3_MODE` (#1098)
 

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -1446,11 +1446,12 @@ routes: {  }";
         if (!$this->tableHasColumnUid($table)) {
             return;
         }
+        $currentAutoIncrement = $this->getAutoIncrement($table);
+        if (!\is_int($currentAutoIncrement)) {
+            return;
+        }
 
-        if (
-            $this->getAutoIncrement($table) >
-            ($this->getMaximumUidFromTable($table) + $this->resetAutoIncrementThreshold)
-        ) {
+        if ($currentAutoIncrement > ($this->getMaximumUidFromTable($table) + $this->resetAutoIncrementThreshold)) {
             $this->resetAutoIncrement($table);
         }
     }
@@ -1506,11 +1507,9 @@ routes: {  }";
      *
      * @param non-empty-string $table the name of the table for which the auto increment value should be retrieved
      *
-     * @return int the current auto_increment value of table $table, will be > 0
-     *
-     * @throws \InvalidArgumentException
+     * @return int|null the current auto_increment value of table $table, will be > 0, or null if the table has none
      */
-    public function getAutoIncrement(string $table): int
+    public function getAutoIncrement(string $table): ?int
     {
         $this->initializeDatabase();
         $this->assertTableNameIsAllowed($table);
@@ -1524,15 +1523,10 @@ routes: {  }";
             $row = $queryResult->fetch();
         }
 
+        \assert(\is_array($row));
         $autoIncrement = $row['Auto_increment'];
-        if ($autoIncrement === null) {
-            throw new \InvalidArgumentException(
-                'The table "' . $table . '" does not have an auto increment value.',
-                1416849363
-            );
-        }
 
-        return (int)$autoIncrement;
+        return \is_numeric($autoIncrement) ? (int)$autoIncrement : null;
     }
 
     /**

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -1002,17 +1002,6 @@ final class TestingFrameworkTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getAutoIncrementReturnsOneForTruncatedTable(): void
-    {
-        self::assertSame(
-            1,
-            $this->subject->getAutoIncrement('tx_oelib_test')
-        );
-    }
-
-    /**
-     * @test
-     */
     public function getAutoIncrementGetsCurrentAutoIncrement(): void
     {
         $uid = $this->subject->createRecord('tx_oelib_test');
@@ -1054,11 +1043,9 @@ final class TestingFrameworkTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getAutoIncrementForSysCategoryRecordMmFails(): void
+    public function getAutoIncrementForSysCategoryRecordMmReturnsNull(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-
-        $this->subject->getAutoIncrement('sys_category_record_mm');
+        self::assertNull($this->subject->getAutoIncrement('sys_category_record_mm'));
     }
 
     /**
@@ -1097,11 +1084,9 @@ final class TestingFrameworkTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getAutoIncrementWithTableWithoutUidFails(): void
+    public function getAutoIncrementWithTableWithoutUidReturnsNull(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The table "tx_oelib_test_article_mm" does not have an auto increment value.');
-        $this->subject->getAutoIncrement('tx_oelib_test_article_mm');
+        self::assertNull($this->subject->getAutoIncrement('tx_oelib_test_article_mm'));
     }
 
     // Tests regarding count()
@@ -1387,23 +1372,6 @@ final class TestingFrameworkTest extends FunctionalTestCase
     }
 
     // Tests regarding resetAutoIncrement()
-
-    /**
-     * @test
-     */
-    public function resetAutoIncrementForTestTableSucceeds(): void
-    {
-        $this->subject->resetAutoIncrement('tx_oelib_test');
-
-        $latestUid = $this->subject->createRecord('tx_oelib_test');
-        $this->getDatabaseConnection()->delete('tx_oelib_test', ['uid' => $latestUid]);
-        $this->subject->resetAutoIncrement('tx_oelib_test');
-
-        self::assertSame(
-            $latestUid,
-            $this->subject->getAutoIncrement('tx_oelib_test')
-        );
-    }
 
     /**
      * @test

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -296,11 +296,6 @@ parameters:
 			path: Classes/Testing/TestingFramework.php
 
 		-
-			message: "#^Cannot access offset 'Auto_increment' on mixed\\.$#"
-			count: 1
-			path: Classes/Testing/TestingFramework.php
-
-		-
 			message: "#^Cannot access offset 'DOCUMENT_ROOT' on mixed\\.$#"
 			count: 1
 			path: Classes/Testing/TestingFramework.php
@@ -467,7 +462,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
-			count: 4
+			count: 3
 			path: Classes/Testing/TestingFramework.php
 
 		-


### PR DESCRIPTION
Getting the auto increment value does not work as before in MySQL 8 (which is used for the ubuntu-20 and ubuntu-22 runners on GitHub actions) anymore.

We'll deprecate this functionality and do damage control until it is removed.

Fixes #1162