### PR TITLE
[TASK] Replace SELECT queries in `AbstractDataMapperTest`

### DIFF
--- a/Classes/Mapper/AbstractDataMapper.php
+++ b/Classes/Mapper/AbstractDataMapper.php
@@ -653,11 +653,13 @@ abstract class AbstractDataMapper
         }
 
         if (\method_exists($result, 'fetchAssociative')) {
+            /** @var DatabaseRow|false $data */
             $data = $result->fetchAssociative();
         } else {
+            /** @var DatabaseRow|false $data */
             $data = $result->fetch();
         }
-        if ($data === false) {
+        if (!\is_array($data)) {
             throw new NotFoundException(
                 'No records found in the table "' . $tableName . '" matching: ' . \json_encode($whereClauseParts)
             );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -216,11 +216,6 @@ parameters:
 			path: Classes/Mapper/AbstractDataMapper.php
 
 		-
-			message: "#^Method OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\:\\:retrieveRecord\\(\\) should return array\\<string, bool\\|float\\|int\\|string\\|null\\> but returns mixed\\.$#"
-			count: 1
-			path: Classes/Mapper/AbstractDataMapper.php
-
-		-
 			message: "#^Parameter \\#1 \\$dataOfModels of method OliverKlee\\\\Oelib\\\\Mapper\\\\AbstractDataMapper\\<M of OliverKlee\\\\Oelib\\\\Model\\\\AbstractModel\\>\\:\\:getListOfModels\\(\\) expects array\\<array\\<string, bool\\|float\\|int\\|string\\|null\\>\\>, array given\\.$#"
 			count: 2
 			path: Classes/Mapper/AbstractDataMapper.php
@@ -577,7 +572,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Result\\:\\:fetch\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: Tests/Functional/Mapper/AbstractDataMapperTest.php
 
 		-


### PR DESCRIPTION
This is in preparation for switching to the TYPO3 testing framework.

Also improve the type annotations in `AbstractDataMapper` a bit.

Part of #1142