### PR TITLE
[TASK] Raise the minimal 11LTS version to 11.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 - Add support for PHP 8.1 (#1127)
-- Add support for TYPO3 11LTS (#1114, #1115, #1123, #1126, #1131, #1136, #1174)
+- Add support for TYPO3 11LTS (#1114, #1115, #1123, #1126, #1131, #1136, #1174, #1180)
 - Add a `ConvertableToMimeAddress` interface and trait (#1092)
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
 		"doctrine/dbal": "^2.10",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",
 		"symfony/mime": "^4.4 || ^5.4 || ^6.1",
-		"typo3/cms-core": "^10.4.11 || ^11.5",
-		"typo3/cms-extbase": "^9.5.16 || ^10.4.11 || ^11.5",
-		"typo3/cms-fluid": "^9.5.16 || ^10.4.11 || ^11.5",
-		"typo3/cms-frontend": "^9.5.16 || ^10.4.11 || ^11.5",
+		"typo3/cms-core": "^10.4.11 || ^11.5.4",
+		"typo3/cms-extbase": "^9.5.16 || ^10.4.11 || ^11.5.4",
+		"typo3/cms-fluid": "^9.5.16 || ^10.4.11 || ^11.5.4",
+		"typo3/cms-frontend": "^9.5.16 || ^10.4.11 || ^11.5.4",
 		"typo3fluid/fluid": "^2.6.10"
 	},
 	"require-dev": {
@@ -51,7 +51,7 @@
 		"saschaegerer/phpstan-typo3": "^1.1.2",
 		"sjbr/static-info-tables": "^6.9.6 || ^11.5.2",
 		"squizlabs/php_codesniffer": "^3.7.1",
-		"typo3/cms-extensionmanager": "^9.5.16 || ^10.4.11 || ^11.5",
+		"typo3/cms-extensionmanager": "^9.5.16 || ^10.4.11 || ^11.5.4",
 		"typo3/testing-framework": "^6.16.6"
 	},
 	"replace": {


### PR DESCRIPTION
This is required to avoid some crashes in the testing framework.