### PR TITLE
[BUGFIX] Always quote version numbers in the CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,23 +134,23 @@ jobs:
           - typo3-version: "^10.4"
             php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 7.4
+          - typo3-version: "^11.5"
+            php-version: "7.4"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 7.4
+          - typo3-version: "^11.5"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 8.0
+          - typo3-version: "^11.5"
+            php-version: "8.0"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 8.0
+          - typo3-version: "^11.5"
+            php-version: "8.0"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 8.1
+          - typo3-version: "^11.5"
+            php-version: "8.1"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 8.1
+          - typo3-version: "^11.5"
+            php-version: "8.1"
             composer-dependencies: highest
   functional-tests:
     name: "Functional tests"
@@ -219,21 +219,21 @@ jobs:
           - typo3-version: "^10.4"
             php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 7.4
+          - typo3-version: "^11.5"
+            php-version: "7.4"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 7.4
+          - typo3-version: "^11.5"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 8.0
+          - typo3-version: "^11.5"
+            php-version: "8.0"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 8.0
+          - typo3-version: "^11.5"
+            php-version: "8.0"
             composer-dependencies: highest
-          - typo3-version: ^11.5
-            php-version: 8.1
+          - typo3-version: "^11.5"
+            php-version: "8.1"
             composer-dependencies: lowest
-          - typo3-version: ^11.5
-            php-version: 8.1
+          - typo3-version: "^11.5"
+            php-version: "8.1"
             composer-dependencies: highest


### PR DESCRIPTION
This avoids YAML rounding PHP 8.0 to "version 8".