### PR TITLE
[BUGFIX] Always create the tests directory on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,8 @@ jobs:
           composer show
       - name: "Start MySQL"
         run: "sudo /etc/init.d/mysql start"
+      - name: "Create the tests directory"
+        run: "mkdir -p .Build/public/typo3temp/var/tests"
       - name: "Run functional tests"
         run: |
           export typo3DatabaseName="typo3";

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -49,6 +49,8 @@ jobs:
         run: "phive install --trust-gpg-keys D8406D0D82947747293778314AA394086372C20A"
       - name: "Start MySQL"
         run: "sudo /etc/init.d/mysql start"
+      - name: "Create the tests directory"
+        run: "mkdir -p .Build/public/typo3temp/var/tests"
       - name: "Run unit tests with coverage"
         run: composer ci:coverage:unit
       - name: "Run functional tests with coverage"


### PR DESCRIPTION
Usually the testing framework automatically does this, but there seems to be a race condition resulting in the directory not getting created.

Fixes #1183