### PR TITLE
[BUGFIX] Reinstantiate the `PriceViewHelper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the `ReadOnlyRepository` trait (#1103)
 - Drop `AbstractDataMapper::countByPageUid` (#1102)
 - Drop `LoginManager::getLoggedInUser` (#1101)
-- Drop the `PriceViewHelper` (#1100)
 - Drop the `GoogleMapsViewHelper` (#1099)
 - Drop `AbstractModel::getAsList` (#1095)
 - Drop support for TYPO3 9LTS (#1094)

--- a/Classes/ViewHelpers/PriceViewHelper.php
+++ b/Classes/ViewHelpers/PriceViewHelper.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Oelib\ViewHelpers;
+
+use OliverKlee\Oelib\Exception\NotFoundException;
+use OliverKlee\Oelib\Mapper\CurrencyMapper;
+use OliverKlee\Oelib\Mapper\MapperRegistry;
+use OliverKlee\Oelib\Model\Currency;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * This class represents a view helper for formatting a price.
+ *
+ * The value (`setValue()`) and the currency (`setCurrencyFromIsoAlpha3Code()`)
+ * should be set before calling `render()`. You can use the same instance of this
+ * view helper to render different values in the same currency by changing the
+ * value via `setValue()`.
+ *
+ * @deprecated will be removed in oelib 6.0; use the `format.currency` view helper instead
+ */
+class PriceViewHelper extends AbstractViewHelper
+{
+    /**
+     * @var float the value of the price to render
+     */
+    protected $value = 0.0;
+
+    /**
+     * @var Currency|null the currency of the price to render
+     */
+    protected $currency = null;
+
+    /**
+     * Sets the value of the price to render.
+     *
+     * @param float $value the value of the price to render, may be negative, positive or zero
+     */
+    public function setValue(float $value): void
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Sets the currency of the price to render based on the currency's ISO
+     * alpha 3 code, e.g. "EUR" for Euro, "USD" for US dollars.
+     *
+     * @param string $isoAlpha3Code the ISO alpha 3 code of the currency to set, must not be empty
+     */
+    public function setCurrencyFromIsoAlpha3Code(string $isoAlpha3Code): void
+    {
+        if (\strlen($isoAlpha3Code) !== 3) {
+            $this->currency = null;
+            return;
+        }
+
+        try {
+            $this->currency = MapperRegistry::get(CurrencyMapper::class)->findByIsoAlpha3Code($isoAlpha3Code);
+        } catch (NotFoundException $exception) {
+            $this->currency = null;
+        }
+    }
+
+    /**
+     * Renders the price based on $this->value and $this->currency.
+     *
+     * Please call setCurrencyFromIsoAlpha3Code() prior to calling render().
+     *
+     * If this function is called without setting a currency first, it will
+     * use some default rendering for the price.
+     *
+     * @return string the rendered price
+     */
+    public function render(): string
+    {
+        $currency = $this->currency;
+        if (!$currency instanceof Currency) {
+            return \number_format($this->value, 2, '.', '');
+        }
+
+        $result = '';
+
+        if ($currency->hasLeftSymbol()) {
+            $result .= $currency->getLeftSymbol() . ' ';
+        }
+
+        $result .= \number_format(
+            $this->value,
+            $currency->getDecimalDigits(),
+            $currency->getDecimalSeparator(),
+            $currency->getThousandsSeparator()
+        );
+
+        if ($currency->hasRightSymbol()) {
+            $result .= ' ' . $currency->getRightSymbol();
+        }
+
+        return $result;
+    }
+}

--- a/Tests/Functional/ViewHelpers/PriceViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/PriceViewHelperTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Oelib\Tests\Functional\ViewHelpers;
+
+use OliverKlee\Oelib\ViewHelpers\PriceViewHelper;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * @covers \OliverKlee\Oelib\ViewHelpers\PriceViewHelper
+ */
+class PriceViewHelperTest extends FunctionalTestCase
+{
+    protected $testExtensionsToLoad = ['typo3conf/ext/oelib', 'typo3conf/ext/static_info_tables'];
+
+    /**
+     * @var PriceViewHelper
+     */
+    private $subject = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importStaticData();
+
+        $this->subject = new PriceViewHelper();
+    }
+
+    /**
+     * Imports static records - but only if they aren't already available as static data.
+     */
+    private function importStaticData(): void
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable('static_currencies');
+        if ($connection->count('*', 'static_currencies', []) === 0) {
+            $this->importDataSet(__DIR__ . '/../Fixtures/Currencies.xml');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function renderAfterSettingAnInvalidCurrencyUsesDecimalPointAndTwoDecimalDigits(): void
+    {
+        $this->subject->setValue(12345.678);
+        $this->subject->setCurrencyFromIsoAlpha3Code('FOO');
+
+        self::assertSame(
+            '12345.68',
+            $this->subject->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function renderForCurrencyWithLeftSymbolRendersCurrencySymbolLeftOfPrice(): void
+    {
+        $this->subject->setValue(123.45);
+        $this->subject->setCurrencyFromIsoAlpha3Code('EUR');
+
+        self::assertSame(
+            '€ 123,45',
+            $this->subject->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function renderForCurrencyWithRightSymbolRendersCurrencySymbolRightOfPrice(): void
+    {
+        $this->subject->setValue(123.45);
+        $this->subject->setCurrencyFromIsoAlpha3Code('CZK');
+
+        self::assertSame(
+            '123,45 Kč',
+            $this->subject->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function renderForCurrencyWithoutDecimalDigitsReturnsPriceWithoutDecimalDigits(): void
+    {
+        $this->subject->setValue(123.45);
+        $this->subject->setCurrencyFromIsoAlpha3Code('CLP');
+
+        self::assertSame(
+            '$ 123',
+            $this->subject->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function renderForCurrencyWithOneDecimalDigitReturnsPriceWithOneDecimalDigit(): void
+    {
+        $this->subject->setValue(123.45);
+        $this->subject->setCurrencyFromIsoAlpha3Code('MGA');
+
+        self::assertSame(
+            '123,5',
+            $this->subject->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function renderForCurrencyWithTwoDecimalDigitsReturnsPriceWithTwoDecimalDigits(): void
+    {
+        $this->subject->setValue(123.45);
+        $this->subject->setCurrencyFromIsoAlpha3Code('EUR');
+
+        self::assertSame(
+            '€ 123,45',
+            $this->subject->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function renderForCurrencyWithCommaAsDecimalSeparatorReturnsPriceWithCommaAsDecimalSeparator(): void
+    {
+        $this->subject->setValue(123.45);
+        $this->subject->setCurrencyFromIsoAlpha3Code('EUR');
+
+        self::assertSame(
+            '€ 123,45',
+            $this->subject->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function renderForCurrencyWithPointAsDecimalSeparatorReturnsPriceWithPointAsDecimalSeparator(): void
+    {
+        $this->subject->setValue(123.45);
+        $this->subject->setCurrencyFromIsoAlpha3Code('USD');
+
+        self::assertSame(
+            '$ 123.45',
+            $this->subject->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function renderForCurrencyWithPointAsThousandsSeparatorReturnsPriceWithPointAsThousandsSeparator(): void
+    {
+        $this->subject->setValue(1234.56);
+        $this->subject->setCurrencyFromIsoAlpha3Code('EUR');
+
+        self::assertSame(
+            '€ 1.234,56',
+            $this->subject->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function renderForCurrencyWithCommaAsThousandsSeparatorReturnsPriceWithCommaAsThousandsSeparator(): void
+    {
+        $this->subject->setValue(1234.56);
+        $this->subject->setCurrencyFromIsoAlpha3Code('USD');
+
+        self::assertSame(
+            '$ 1,234.56',
+            $this->subject->render()
+        );
+    }
+}

--- a/Tests/Unit/ViewHelpers/PriceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/PriceViewHelperTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Oelib\Tests\Unit\ViewHelpers;
+
+use OliverKlee\Oelib\ViewHelpers\PriceViewHelper;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
+
+/**
+ * @covers \OliverKlee\Oelib\ViewHelpers\PriceViewHelper
+ */
+class PriceViewHelperTest extends UnitTestCase
+{
+    /**
+     * @var PriceViewHelper
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new PriceViewHelper();
+    }
+
+    /**
+     * @test
+     */
+    public function isViewHelper(): void
+    {
+        self::assertInstanceOf(AbstractViewHelper::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsViewHelper(): void
+    {
+        self::assertInstanceOf(ViewHelperInterface::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithoutSettingValueOrCurrencyFirstRendersZeroWithTwoDigits(): void
+    {
+        self::assertSame(
+            '0.00',
+            $this->subject->render()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function renderWithValueWithoutSettingCurrencyUsesDecimalPointAndTwoDecimalDigits(): void
+    {
+        $this->subject->setValue(12345.678);
+
+        self::assertSame(
+            '12345.68',
+            $this->subject->render()
+        );
+    }
+}


### PR DESCRIPTION
This view helper is still used in the seminars extensions and should note have been removed.

This mostly reverts commit 37a8483a972e9830d042b8c4b477a47f6c099b9a.

Fixes #1193