### PR TITLE
[BUGFIX] Stop using `static` in callables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for TYPO3 9LTS (#1094, #1206)
 
 ### Fixed
+- Stop using `static` in callables (#1209)
 - Stop using the deprecated `strftime` (#1207)
 - Harden the `ConfigurationRegistry` (#1195)
 - Fix invalid array accesses in `TestingFramework` (#1179)

--- a/Classes/ViewHelpers/AbstractConfigurationCheckViewHelper.php
+++ b/Classes/ViewHelpers/AbstractConfigurationCheckViewHelper.php
@@ -59,7 +59,7 @@ abstract class AbstractConfigurationCheckViewHelper extends AbstractViewHelper
         }
         $configuration = new ExtbaseConfiguration($settings);
         $configurationCheckClassName = static::getConfigurationCheckClassName();
-        $configurationCheck = new $configurationCheckClassName($configuration, static::getConfigurationNamespace());
+        $configurationCheck = new $configurationCheckClassName($configuration, self::getConfigurationNamespace());
         $configurationCheck->check();
 
         return \implode("\n", $configurationCheck->getWarningsAsHtml());


### PR DESCRIPTION
This is deprecated in PHP 8.2.