### PR TITLE
[TASK] Do not run the PHP 8.2 tests with the lowest dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,6 @@ jobs:
             composer-dependencies: highest
           - typo3-version: "^11.5"
             php-version: "8.2"
-            composer-dependencies: lowest
-          - typo3-version: "^11.5"
-            php-version: "8.2"
             composer-dependencies: highest
   functional-tests:
     name: "Functional tests"
@@ -260,9 +257,6 @@ jobs:
           - typo3-version: "^11.5"
             php-version: "8.1"
             composer-dependencies: highest
-          - typo3-version: "^11.5"
-            php-version: "8.2"
-            composer-dependencies: lowest
           - typo3-version: "^11.5"
             php-version: "8.2"
             composer-dependencies: highest


### PR DESCRIPTION
We need some bug fixes in newer versions of the dependencies to have the PHP 8.2 build warning-free.