### PR TITLE
[BUGFIX] Remove the deprecated `cruser_id` configuration for test tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Remove the deprecated `cruser_id` configuration for the test tables (#1458)
 - Avoid using the deprecated `ObjectManager` in tests (#1457)
 - Add a 12LTS-specific method to `TestingQueryResult` (#1454)
 - Improve some type annotations (#1453)

--- a/Configuration/TCA/tx_oelib_test.php
+++ b/Configuration/TCA/tx_oelib_test.php
@@ -6,7 +6,6 @@ return [
     'ctrl' => [
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'versioningWS' => false,
         'delete' => 'deleted',
         'enablecolumns' => [

--- a/Configuration/TCA/tx_oelib_testchild.php
+++ b/Configuration/TCA/tx_oelib_testchild.php
@@ -6,7 +6,6 @@ return [
     'ctrl' => [
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'versioningWS' => false,
         'delete' => 'deleted',
         'hideTable' => true,


### PR DESCRIPTION
These tables cannot be created manually in the BE anyway.