### PR TITLE
[TASK] Move some templating tests to functionals

### DIFF
--- a/Tests/Functional/Templating/TemplateRegistryTest.php
+++ b/Tests/Functional/Templating/TemplateRegistryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Oelib\Tests\Functional\Templating;
+
+use OliverKlee\Oelib\Templating\Template;
+use OliverKlee\Oelib\Templating\TemplateRegistry;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * @covers \OliverKlee\Oelib\Templating\TemplateRegistry
+ */
+final class TemplateRegistryTest extends FunctionalTestCase
+{
+    protected $testExtensionsToLoad = ['typo3conf/ext/oelib'];
+
+    protected $initializeDatabase = false;
+
+    // Tests concerning the Singleton property
+
+    /**
+     * @test
+     */
+    public function getForExistingTemplateFileNameReturnsTemplate(): void
+    {
+        self::assertInstanceOf(
+            Template::class,
+            TemplateRegistry::get('EXT:oelib/Tests/Functional/Fixtures/Template.html')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getForExistingTemplateFileNameCalledTwoTimesReturnsNewInstance(): void
+    {
+        self::assertNotSame(
+            TemplateRegistry::get('EXT:oelib/Tests/Functional/Fixtures/Template.html'),
+            TemplateRegistry::get('EXT:oelib/Tests/Functional/Fixtures/Template.html')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getForExistingTemplateFileNameReturnsProcessedTemplate(): void
+    {
+        $template = TemplateRegistry::get('EXT:oelib/Tests/Functional/Fixtures/Template.html');
+
+        self::assertSame(
+            "Hello world!\n",
+            $template->getSubpart()
+        );
+    }
+}

--- a/Tests/Functional/Templating/TemplateTest.php
+++ b/Tests/Functional/Templating/TemplateTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Oelib\Tests\Functional\Templating;
+
+use OliverKlee\Oelib\Templating\Template;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * @covers \OliverKlee\Oelib\Templating\Template
+ */
+final class TemplateTest extends FunctionalTestCase
+{
+    protected $testExtensionsToLoad = ['typo3conf/ext/oelib'];
+
+    protected $initializeDatabase = false;
+
+    /**
+     * @var Template
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Template();
+    }
+
+    // Tests for reading the HTML from a file.
+
+    /**
+     * @test
+     */
+    public function processTemplateFromFileProcessesTemplateFromFile(): void
+    {
+        $this->subject->processTemplateFromFile('EXT:oelib/Tests/Functional/Fixtures/Template.html');
+
+        self::assertSame("Hello world!\n", $this->subject->render());
+    }
+}

--- a/Tests/Unit/Templating/TemplateRegistryTest.php
+++ b/Tests/Unit/Templating/TemplateRegistryTest.php
@@ -74,39 +74,4 @@ final class TemplateRegistryTest extends UnitTestCase
             TemplateRegistry::get('')
         );
     }
-
-    /**
-     * @test
-     */
-    public function getForExistingTemplateFileNameReturnsTemplate(): void
-    {
-        self::assertInstanceOf(
-            Template::class,
-            TemplateRegistry::get('EXT:oelib/Tests/Functional/Fixtures/Template.html')
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function getForExistingTemplateFileNameCalledTwoTimesReturnsNewInstance(): void
-    {
-        self::assertNotSame(
-            TemplateRegistry::get('EXT:oelib/Tests/Functional/Fixtures/Template.html'),
-            TemplateRegistry::get('EXT:oelib/Tests/Functional/Fixtures/Template.html')
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function getForExistingTemplateFileNameReturnsProcessedTemplate(): void
-    {
-        $template = TemplateRegistry::get('EXT:oelib/Tests/Functional/Fixtures/Template.html');
-
-        self::assertSame(
-            "Hello world!\n",
-            $template->getSubpart()
-        );
-    }
 }

--- a/Tests/Unit/Templating/TemplateTest.php
+++ b/Tests/Unit/Templating/TemplateTest.php
@@ -25,23 +25,6 @@ final class TemplateTest extends UnitTestCase
         $this->subject = new Template();
     }
 
-    // Tests for reading the HTML from a file.
-
-    /**
-     * @test
-     */
-    public function processTemplateFromFileProcessesTemplateFromFile(): void
-    {
-        $this->subject->processTemplateFromFile(
-            'EXT:oelib/Tests/Functional/Fixtures/Template.html'
-        );
-
-        self::assertSame(
-            "Hello world!\n",
-            $this->subject->render()
-        );
-    }
-
     // Tests for getting subparts.
 
     /**


### PR DESCRIPTION
For TYPO3 12LTS, we need functional tests for theses tests in order to resolved loaded extensions.