### PR TITLE
[TASK] Stop extending the deprecated `AbstractPlugin` (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Stop extending the deprecated `AbstractPlugin` (#1487)
 - Avoid using the deprecated `GeneralUtility::_GP` (#1482)
 - Fix type errors in the testing framework (#1480)
 

--- a/Tests/Functional/Language/Fixtures/TestingSalutationSwitcher.php
+++ b/Tests/Functional/Language/Fixtures/TestingSalutationSwitcher.php
@@ -24,6 +24,44 @@ final class TestingSalutationSwitcher extends SalutationSwitcher
     public $extKey = 'oelib';
 
     /**
+     * Flag that tells if the locallang file has been fetch (or tried to
+     * be fetched) already.
+     *
+     * @var bool
+     */
+    public $LOCAL_LANG_loaded = false;
+
+    /**
+     * Pointer to the language to use.
+     *
+     * @var string
+     */
+    public $LLkey = 'default';
+
+    /**
+     * Pointer to alternative fall-back language to use.
+     *
+     * @var string
+     */
+    public $altLLkey = '';
+
+    /**
+     * You can set this during development to some value that makes it
+     * easy for you to spot all labels that ARe delivered by the getLL function.
+     *
+     * @var string
+     */
+    public $LLtestPrefix = '';
+
+    /**
+     * Save as LLtestPrefix, but additional prefix for the alternative value
+     * in getLL() function calls
+     *
+     * @var string
+     */
+    public $LLtestPrefixAlt = '';
+
+    /**
      * The constructor.
      *
      * @param array<string, mixed> $configuration TypoScript setup configuration, may be empty
@@ -34,7 +72,6 @@ final class TestingSalutationSwitcher extends SalutationSwitcher
 
         $this->conf = $configuration;
 
-        $this->pi_setPiVarDefaults();
         $this->pi_loadLL();
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -161,12 +161,57 @@ parameters:
 			path: Classes/Geocoding/GoogleGeocoding.php
 
 		-
+			message: "#^Cannot call method getLanguage\\(\\) on mixed\\.$#"
+			count: 1
+			path: Classes/Language/SalutationSwitcher.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 3
+			path: Classes/Language/SalutationSwitcher.php
+
+		-
 			message: "#^Method OliverKlee\\\\Oelib\\\\Language\\\\SalutationSwitcher\\:\\:getFrontEndController\\(\\) should return TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\|null but returns mixed\\.$#"
 			count: 1
 			path: Classes/Language/SalutationSwitcher.php
 
 		-
 			message: "#^Method OliverKlee\\\\Oelib\\\\Language\\\\SalutationSwitcher\\:\\:getLanguageService\\(\\) should return TYPO3\\\\CMS\\\\Core\\\\Localization\\\\LanguageService\\|null but returns mixed\\.$#"
+			count: 1
+			path: Classes/Language/SalutationSwitcher.php
+
+		-
+			message: "#^Only booleans are allowed in an elseif condition, string given\\.$#"
+			count: 1
+			path: Classes/Language/SalutationSwitcher.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Language\\\\SalutationSwitcher\\:\\:\\$LLtestPrefix \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: Classes/Language/SalutationSwitcher.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Language\\\\SalutationSwitcher\\:\\:\\$LLtestPrefixAlt \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: Classes/Language/SalutationSwitcher.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Language\\\\SalutationSwitcher\\:\\:\\$LOCAL_LANG type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Language/SalutationSwitcher.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Language\\\\SalutationSwitcher\\:\\:\\$LOCAL_LANG_UNSET type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Language/SalutationSwitcher.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Language\\\\SalutationSwitcher\\:\\:\\$conf type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Language/SalutationSwitcher.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Language\\\\SalutationSwitcher\\:\\:\\$frontendController \\(TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\) does not accept mixed\\.$#"
 			count: 1
 			path: Classes/Language/SalutationSwitcher.php
 


### PR DESCRIPTION
This part is about making the (deprecated) `SalutationSwitcher` independent from `AbstractPlugin`.