### PR TITLE
[TASK] Stop extending the deprecated `AbstractPlugin` (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
-- Stop extending the deprecated `AbstractPlugin` (#1487)
+- Stop extending the deprecated `AbstractPlugin` (#1487, #1488)
 - Avoid using the deprecated `GeneralUtility::_GP` (#1482)
 - Fix type errors in the testing framework (#1480)
 

--- a/Classes/Language/SalutationSwitcher.php
+++ b/Classes/Language/SalutationSwitcher.php
@@ -414,9 +414,10 @@ abstract class SalutationSwitcher
         }
 
         if ($this->scriptRelPath !== '') {
-            $languageFilePath = 'EXT:' . $this->extKey . '/' . PathUtility::dirname(
-                $this->scriptRelPath
-            ) . '/locallang.xlf';
+            $languageFilePath = 'EXT:' . $this->extKey . '/'
+                . PathUtility::dirname($this->scriptRelPath) . '/locallang.xlf';
+        } else {
+            $languageFilePath = '';
         }
         if ($languageFilePath !== '') {
             $languageFactory = GeneralUtility::makeInstance(LocalizationFactory::class);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -296,6 +296,46 @@ parameters:
 			path: Classes/Templating/Template.php
 
 		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Cannot call method getLanguage\\(\\) on mixed\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 4
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Casting to int something that's already int\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 6
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Constructor of class OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper has an unused parameter \\$_\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
+			path: Classes/Templating/TemplateHelper.php
+
+		-
 			message: "#^Method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:getFrontEndController\\(\\) should return TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\|null but returns mixed\\.$#"
 			count: 1
 			path: Classes/Templating/TemplateHelper.php
@@ -303,6 +343,161 @@ parameters:
 		-
 			message: "#^Method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:getLanguageService\\(\\) should return TYPO3\\\\CMS\\\\Core\\\\Localization\\\\LanguageService\\|null but returns mixed\\.$#"
 			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:pi_autoCache\\(\\) has parameter \\$inArray with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:pi_getFFvalue\\(\\) has parameter \\$T3FlexForm_array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:pi_getFFvalueFromSheetArray\\(\\) has parameter \\$fieldNameArr with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:pi_getFFvalueFromSheetArray\\(\\) has parameter \\$sheetArray with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:pi_linkTP\\(\\) has parameter \\$urlParameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:pi_linkTP_keepPIvars\\(\\) has parameter \\$overrulePIvars with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:pi_list_browseresults\\(\\) has parameter \\$wrapArr with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:translateInFrontEnd\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int\\<\\-1, 1\\> given\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Only booleans are allowed in an elseif condition, int\\<0, max\\> given\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Only booleans are allowed in an elseif condition, string given\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method TYPO3\\\\CMS\\\\Core\\\\Service\\\\MarkerBasedTemplateService\\:\\:substituteMarkerArray\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\:\\:wrap\\(\\) expects string, int given\\.$#"
+			count: 3
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\:\\:wrap\\(\\) expects string, string\\|null given\\.$#"
+			count: 4
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of method OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:pi_linkTP_keepPIvars\\(\\) expects string, string\\|null given\\.$#"
+			count: 4
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, string\\|null given\\.$#"
+			count: 9
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$string1 of function strcmp expects string, mixed given\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:\\$LLtestPrefix \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:\\$LLtestPrefixAlt \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:\\$LOCAL_LANG type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:\\$LOCAL_LANG_UNSET type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:\\$conf type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:\\$frontendController \\(TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\) does not accept mixed\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:\\$internal type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:\\$piVars type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Property OliverKlee\\\\Oelib\\\\Templating\\\\TemplateHelper\\:\\:\\$pi_autoCacheFields type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 1
+			path: Classes/Templating/TemplateHelper.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 6
 			path: Classes/Templating/TemplateHelper.php
 
 		-


### PR DESCRIPTION
This part is about making the `TemplateHelper`
independent from `AbstractPlugin`.