### PR TITLE
[BUGFIX] Mark the `Configuration` classes as non-injectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Mark the `Configuration` classes and the interface as non-injectable (#1512)
 - Stop accessing the `TYPO3_MODE` constant (#1495)
 - Skip the legacy template loading in the TF in TYPO3 V12 (#1490)
 - Stop extending the deprecated `AbstractPlugin` (#1487, #1488)

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,4 +6,4 @@ services:
 
   OliverKlee\Oelib\:
     resource: '../Classes/*'
-    exclude: '../Classes/DataStructures/*,../Classes/Domain/Model/*,../Classes/Model/*'
+    exclude: '../Classes/Configuration/*,../Classes/DataStructures/*,../Classes/Domain/Model/*,../Classes/Interfaces/Configuration.php,../Classes/Model/*'


### PR DESCRIPTION
Fixes #1267