### PR TITLE
[TASK] Re-enable the legacy template parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 - Mark the `Configuration` classes and the interface as non-injectable (#1512)
 - Stop accessing the `TYPO3_MODE` constant (#1495)
-- Skip the legacy template loading in the TF in TYPO3 V12 (#1490)
 - Stop extending the deprecated `AbstractPlugin` (#1487, #1488)
 - Avoid using the deprecated `GeneralUtility::_GP` (#1482)
 - Fix type errors in the testing framework (#1480)

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -932,12 +932,7 @@ final class TestingFramework
             $frontEnd->id = $pageUid;
         }
         $frontEnd->determineId($request);
-        if ((new Typo3Version())->getMajorVersion() <= 11) {
-            $template = GeneralUtility::makeInstance(TemplateService::class);
-            $frontEnd->tmpl = $template;
-        } else {
-            $template = null;
-        }
+        $frontEnd->tmpl = GeneralUtility::makeInstance(TemplateService::class);
         $frontEnd->config = [
             'config' => ['MP_disableTypolinkClosestMPvalue' => true, 'typolinkLinkAccessRestrictedPages' => true],
         ];
@@ -949,11 +944,9 @@ final class TestingFramework
                 $rootLine = [];
             }
 
-            if ($template !== null) {
-                $frontEnd->tmpl->runThroughTemplates($rootLine);
-                $frontEnd->tmpl->generateConfig();
-                $frontEnd->tmpl->loaded = true;
-            }
+            $frontEnd->tmpl->runThroughTemplates($rootLine);
+            $frontEnd->tmpl->generateConfig();
+            $frontEnd->tmpl->loaded = true;
             Locales::setSystemLocaleFromSiteLanguage($frontEnd->getLanguage());
         }
 

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -10,7 +10,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
@@ -2338,10 +2337,6 @@ final class TestingFrameworkTest extends FunctionalTestCase
      */
     public function createFakeFrontEndCreatesTemplate(): void
     {
-        if ((new Typo3Version())->getMajorVersion() >= 12) {
-            self::markTestSkipped('This test is not compatible with TYPO3 V12.');
-        }
-
         $pageUid = $this->subject->createFrontEndPage();
         $this->subject->createFakeFrontEnd($pageUid);
 
@@ -2353,10 +2348,6 @@ final class TestingFrameworkTest extends FunctionalTestCase
      */
     public function createFakeFrontEndReadsTypoScriptSetupFromPage(): void
     {
-        if ((new Typo3Version())->getMajorVersion() >= 12) {
-            self::markTestSkipped('This test is not compatible with TYPO3 V12.');
-        }
-
         $pageUid = $this->subject->createFrontEndPage();
         $this->subject->createTemplate(
             $pageUid,
@@ -2376,10 +2367,6 @@ final class TestingFrameworkTest extends FunctionalTestCase
      */
     public function createFakeFrontEndWithTemplateRecordMarksTemplateAsLoaded(): void
     {
-        if ((new Typo3Version())->getMajorVersion() >= 12) {
-            self::markTestSkipped('This test is not compatible with TYPO3 V12.');
-        }
-
         $pageUid = $this->subject->createFrontEndPage();
         $this->subject->createTemplate(
             $pageUid,


### PR DESCRIPTION
This change was potentially breaking. We should replace it with something functional instead at a later point.

This reverts commit 43c0bf9abf2e0d4bb7c09c0440a146f0df943ec4.

Fixes #1515