### PR TITLE
[TASK] Use our own copy of the PHPUnit configuration files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,8 @@
 /.phive/ export-ignore
 /.php-cs-fixer.php export-ignore
 /.php_cs.dist export-ignore
+/Configuration/FunctionalTests.xml export-ignore
+/Configuration/UnitTests.xml export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /Resources/Private/Patches/ export-ignore
 /Tests/ export-ignore

--- a/Configuration/FunctionalTests.xml
+++ b/Configuration/FunctionalTests.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+         backupGlobals="true"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
+         cacheResult="false"
+         colors="true"
+         convertDeprecationsToExceptions="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         forceCoversAnnotation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         verbose="false"
+>
+
+    <php>
+        <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
+        <const name="TYPO3_MODE" value="BE"/>
+        <!--
+            @deprecated: Set this to not suppress warnings, notices and deprecations in functional tests
+                         with TYPO3 core v11 and up.
+                         Will always be done with next major version.
+                         To still suppress warnings, notices and deprecations, do NOT define the constant at all.
+         -->
+        <!--        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true"/>-->
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+</phpunit>

--- a/Configuration/UnitTests.xml
+++ b/Configuration/UnitTests.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+         backupGlobals="true"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+         cacheResult="false"
+         colors="true"
+         convertDeprecationsToExceptions="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         forceCoversAnnotation="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         verbose="false"
+>
+
+    <php>
+        <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
+        <const name="TYPO3_MODE" value="BE" />
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+</phpunit>

--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,7 @@
 		],
 		"ci:coverage:functional": [
 			"@coverage:create-directories",
-			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml --whitelist Classes --coverage-php=\".Build/coverage/{}.cov\" {}';"
+			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c Configuration/FunctionalTests.xml --whitelist Classes --coverage-php=\".Build/coverage/{}.cov\" {}';"
 		],
 		"ci:coverage:merge": [
 			"@coverage:create-directories",
@@ -117,7 +117,7 @@
 		],
 		"ci:coverage:unit": [
 			"@coverage:create-directories",
-			".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
+			".Build/vendor/bin/phpunit -c Configuration/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
 		],
 		"ci:dynamic": [
 			"@ci:tests"
@@ -138,8 +138,8 @@
 			"@ci:tests:unit",
 			"@ci:tests:functional"
 		],
-		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml {}';",
-		"ci:tests:unit": ".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit/",
+		"ci:tests:functional": "find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c Configuration/FunctionalTests.xml {}';",
+		"ci:tests:unit": ".Build/vendor/bin/phpunit -c Configuration/UnitTests.xml Tests/Unit",
 		"coverage:create-directories": "mkdir -p build/logs .Build/coverage",
 		"fix": [
 			"@fix:composer",
@@ -168,6 +168,8 @@
 			"rm .gitattributes",
 			"rm .gitignore",
 			"rm .php-cs-fixer.php",
+			"rm Configuration/FunctionalTests.xml",
+			"rm Configuration/UnitTests.xml",
 			"rm composer.lock",
 			"rm crowdin.yml",
 			"rm phpcs.xml.dist",


### PR DESCRIPTION
Also disable deprecation warnings for the functional tests.

Fixes #1516