### PR TITLE
[TASK] De-deprecate `Currency` model/mapper and `PriceViewHelper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Mark some classes and methods as `@internal` (#1478, #1522, #1561, #1565)
 
  ### Deprecated
+- De-deprecate the `PriceViewHelper` (#1591)
+- De-deprecate the `Currency` model and mapper (#1591)
 - De-deprecate the `Country` and `Language` models and mappers (#1562)
 - Deprecate `TestingFramework::createBackEndUser()` (#1555)
 - Deprecate `TestingFramework::isLoggedIn()` (#1554)

--- a/Classes/Mapper/CurrencyMapper.php
+++ b/Classes/Mapper/CurrencyMapper.php
@@ -9,8 +9,6 @@ use OliverKlee\Oelib\Model\Currency;
 
 /**
  * @extends AbstractDataMapper<Currency>
- *
- * @deprecated will be removed in oelib 6.0
  */
 class CurrencyMapper extends AbstractDataMapper
 {

--- a/Classes/Model/Currency.php
+++ b/Classes/Model/Currency.php
@@ -6,8 +6,6 @@ namespace OliverKlee\Oelib\Model;
 
 /**
  * This class represents a currency.
- *
- * @deprecated will be removed in oelib 6.0
  */
 class Currency extends AbstractModel
 {

--- a/Classes/ViewHelpers/PriceViewHelper.php
+++ b/Classes/ViewHelpers/PriceViewHelper.php
@@ -17,8 +17,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  * should be set before calling `render()`. You can use the same instance of this
  * view helper to render different values in the same currency by changing the
  * value via `setValue()`.
- *
- * @deprecated will be removed in oelib 6.0; use the `format.currency` view helper instead
  */
 class PriceViewHelper extends AbstractViewHelper
 {


### PR DESCRIPTION
Those are still in use in seminars.