### PR TITLE
[BUGFIX] Return empty string in `FrontEndUser::getName()` for no name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Return an empty string in `FrontEndUser::getName()` for no name set (#1592)
 - Avoid additional query in `TestingFramework::changeRecord` (#1588)
 - Mark the `Configuration` classes and the interface as non-injectable (#1512)
 - Stop accessing the `TYPO3_MODE` constant (#1495)

--- a/Classes/Model/FrontEndUser.php
+++ b/Classes/Model/FrontEndUser.php
@@ -134,7 +134,7 @@ class FrontEndUser extends AbstractModel implements MailRole, Address, Convertab
         } elseif ($this->hasFirstName() || $this->hasLastName()) {
             $result = trim($this->getFirstName() . ' ' . $this->getLastName());
         } else {
-            $result = $this->getUserName();
+            $result = '';
         }
 
         return $result;

--- a/Tests/Unit/Model/FrontEndUserTest.php
+++ b/Tests/Unit/Model/FrontEndUserTest.php
@@ -378,7 +378,7 @@ final class FrontEndUserTest extends UnitTestCase
     /**
      * @test
      */
-    public function getNameForEmptyFirstAndLastNameAndNonEmptyUserNameReturnsUserName(): void
+    public function getNameForEmptyFirstAndLastNameAndNonEmptyUserNameReturnsEmptyString(): void
     {
         $this->subject->setData(
             [
@@ -388,10 +388,7 @@ final class FrontEndUserTest extends UnitTestCase
             ]
         );
 
-        self::assertSame(
-            'johndoe',
-            $this->subject->getName()
-        );
+        self::assertSame('', $this->subject->getName());
     }
 
     /**


### PR DESCRIPTION
A username is not a meaningful substitute for a real name after all.

Fixes #1586