### PR TITLE
[TASK] Reduce the visibility of some `AbstractDataMapper` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 - Drop deprecated methods from `AbstractDataMapper`
-  (#1640, #1641, #1642, #1643, #1644)
+  (#1640, #1641, #1642, #1643, #1644, #1645)
 - Drop `TestingFramework::count()` and `::existsRecordWithUid` (#1639)
 - Drop the tracking of changed records from the testing framework (#1638)
 - Drop the logging-related interfaces/traits (#1637)

--- a/Classes/Mapper/AbstractDataMapper.php
+++ b/Classes/Mapper/AbstractDataMapper.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\ResultStatement;
 use OliverKlee\Oelib\DataStructures\Collection;
 use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Model\AbstractModel;
-use OliverKlee\Oelib\Testing\TestingFramework;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -41,16 +40,15 @@ abstract class AbstractDataMapper
     protected $columns = '*';
 
     /**
-     * @var IdentityMap a map that holds the models that already
-     *                           have been retrieved
+     * @var IdentityMap a map that holds the models that already have been retrieved
      */
-    protected $map;
+    private $map;
 
     /**
      * @var array<positive-int, true> UIDs of models that are memory-only models that must not be saved,
      *      using the UIDs as keys and TRUE as value
      */
-    protected $uidsOfMemoryOnlyDummyModels = [];
+    private $uidsOfMemoryOnlyDummyModels = [];
 
     /**
      * @var array<non-empty-string, class-string<AbstractDataMapper>>
@@ -77,11 +75,6 @@ abstract class AbstractDataMapper
     private $denyDatabaseAccess = false;
 
     /**
-     * @var TestingFramework|null
-     */
-    protected $testingFramework;
-
-    /**
      * The constructor.
      */
     public function __construct()
@@ -103,15 +96,6 @@ abstract class AbstractDataMapper
         foreach ($this->additionalKeys as $key) {
             $this->cacheByKey[$key] = [];
         }
-    }
-
-    /**
-     * Sets the testing framework. During functional tests, this makes sure that records created with this mapper
-     * will be deleted during cleanUp again.
-     */
-    public function setTestingFramework(TestingFramework $testingFramework): void
-    {
-        $this->testingFramework = $testingFramework;
     }
 
     /**

--- a/Classes/Mapper/MapperRegistry.php
+++ b/Classes/Mapper/MapperRegistry.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OliverKlee\Oelib\Mapper;
 
-use OliverKlee\Oelib\Testing\TestingFramework;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -30,16 +29,6 @@ class MapperRegistry
      * @deprecated #1594 will be removed in oelib 6.0
      */
     private $denyDatabaseAccess = false;
-
-    /**
-     * @var bool whether this MapperRegistry is used in testing mode
-     */
-    private $testingMode = false;
-
-    /**
-     * @var TestingFramework the testingFramework to use in testing mode
-     */
-    private $testingFramework;
 
     /**
      * The constructor. Use getInstance() instead.
@@ -118,9 +107,6 @@ class MapperRegistry
             $this->mappers[$className] = $mapper;
         }
 
-        if ($this->testingMode) {
-            $mapper->setTestingFramework($this->testingFramework);
-        }
         // @deprecated #1594 will be removed in oelib 6.0
         if ($this->denyDatabaseAccess) {
             $mapper->disableDatabaseAccess();
@@ -137,15 +123,6 @@ class MapperRegistry
     public static function denyDatabaseAccess(): void
     {
         self::getInstance()->denyDatabaseAccess = true;
-    }
-
-    /**
-     * Activates the testing mode. This automatically will activate the testing mode for all future mappers.
-     */
-    public function activateTestingMode(TestingFramework $testingFramework): void
-    {
-        $this->testingMode = true;
-        $this->testingFramework = $testingFramework;
     }
 
     /**

--- a/Tests/Unit/Mapper/AbstractDataMapperTest.php
+++ b/Tests/Unit/Mapper/AbstractDataMapperTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OliverKlee\Oelib\Tests\Unit\Mapper;
 
 use OliverKlee\Oelib\Exception\NotFoundException;
-use OliverKlee\Oelib\Mapper\IdentityMap;
 use OliverKlee\Oelib\Mapper\MapperRegistry;
 use OliverKlee\Oelib\Model\AbstractModel;
 use OliverKlee\Oelib\Tests\Unit\Mapper\Fixtures\ColumnLessTestingMapper;
@@ -196,24 +195,6 @@ final class AbstractDataMapperTest extends UnitTestCase
 
         // @phpstan-ignore-next-line We're testing for a contract violation here.
         $this->subject->find(-1);
-    }
-
-    /**
-     * @test
-     */
-    public function findWithUidOfCachedModelReturnsThatModel(): void
-    {
-        $model = new TestingModel();
-        $model->setUid(1);
-
-        $map = new IdentityMap();
-        $map->add($model);
-        $this->subject->setMap($map);
-
-        self::assertSame(
-            $model,
-            $this->subject->find(1)
-        );
     }
 
     /**

--- a/Tests/Unit/Mapper/Fixtures/TestingMapper.php
+++ b/Tests/Unit/Mapper/Fixtures/TestingMapper.php
@@ -7,7 +7,6 @@ namespace OliverKlee\Oelib\Tests\Unit\Mapper\Fixtures;
 use OliverKlee\Oelib\Exception\NotFoundException;
 use OliverKlee\Oelib\Mapper\AbstractDataMapper;
 use OliverKlee\Oelib\Mapper\FrontEndUserMapper;
-use OliverKlee\Oelib\Mapper\IdentityMap;
 use OliverKlee\Oelib\Model\AbstractModel;
 use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\TestingModel;
 
@@ -50,14 +49,6 @@ final class TestingMapper extends AbstractDataMapper
     public function getCachedModels(): array
     {
         return $this->cachedModels;
-    }
-
-    /**
-     * Sets the map for this mapper.
-     */
-    public function setMap(IdentityMap $map): void
-    {
-        $this->map = $map;
     }
 
     /**


### PR DESCRIPTION
Also drop some now-unused properties and a meaningless test.

Fixes #1583