### PR TITLE
[TASK] Bump the development dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,7 @@ updates:
     ignore:
       - dependency-name: "doctrine/dbal"
       - dependency-name: "ergebnis/composer-normalize"
-        versions: [ ">= 2.19.0" ]
-      - dependency-name: "friendsofphp/php-cs-fixer"
-        versions: [ ">= 3.4.0" ]
+        versions: [ ">= 2.29.0" ]
       - dependency-name: "phpunit/phpunit"
         versions: [ ">= 10" ]
       - dependency-name: "sjbr/static-info-tables"

--- a/composer.json
+++ b/composer.json
@@ -36,13 +36,13 @@
 		"typo3fluid/fluid": "^2.6.10"
 	},
 	"require-dev": {
-		"ergebnis/composer-normalize": "^2.19.0",
-		"friendsofphp/php-cs-fixer": "^3.4.0",
+		"ergebnis/composer-normalize": "~2.28.3",
+		"friendsofphp/php-cs-fixer": "^3.42.0",
 		"php-coveralls/php-coveralls": "^2.7.0",
 		"phpstan/extension-installer": "^1.3.1",
-		"phpstan/phpstan": "^1.10.50",
+		"phpstan/phpstan": "^1.10.27",
 		"phpstan/phpstan-phpunit": "^1.3.15",
-		"phpstan/phpstan-strict-rules": "^1.5.2",
+		"phpstan/phpstan-strict-rules": "^1.5.1",
 		"phpunit/phpunit": "^9.6.15",
 		"saschaegerer/phpstan-typo3": "^1.9.1",
 		"sjbr/static-info-tables": "^6.9.6 || ^11.5.5 || ^12.4.2",
@@ -118,7 +118,7 @@
 		"ci:dynamic": [
 			"@ci:tests"
 		],
-		"ci:php:cs-fixer": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --diff",
+		"ci:php:cs-fixer": "php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --diff",
 		"ci:php:lint": "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
 		"ci:php:rector": ".Build/vendor/bin/rector --dry-run",
 		"ci:php:sniff": ".Build/vendor/bin/phpcs Classes Configuration Tests",
@@ -146,7 +146,7 @@
 			"@fix:php:cs",
 			"@fix:php:sniff"
 		],
-		"fix:php:cs": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --config .php-cs-fixer.php",
+		"fix:php:cs": "php-cs-fixer fix --config .php-cs-fixer.php",
 		"fix:php:sniff": "phpcbf Classes Configuration Tests",
 		"link-extension": [
 			"@php -r 'is_dir($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/\") || mkdir($extFolder, 0777, true);'",


### PR DESCRIPTION
Also drop the workaround for older versions of PHP-CS-Fixer with PHP 8.2.

Fixes #1439