### PR TITLE
[BUGFIX] Stop using the deprecated `Connection::PARAM_INT_ARRAY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP < 7.4 (#1597)
 
 ### Fixed
-- Switch to the new DBAL methods (#1656, #1657, #1658)
+- Switch to the new DBAL methods (#1656, #1657, #1658, #1674)
 
 ## 5.2.2
 

--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OliverKlee\Oelib\Domain\Repository;
 
-use Doctrine\DBAL\Connection;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\SingletonInterface;


### PR DESCRIPTION
Fixes #1673