### PR TITLE
[BUGFIX] Properly set the `DateTimeAspect` in the tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Add Rector to our toolchain (#1659, #1662)
 
 ### Changed
-- Use the `Context` for getting the current timestamp (#1682)
+- Use the `Context` for getting the current timestamp (#1682, #1684)
 - Use more native type declarations (#1664, #1665)
 - Upgrade to PHPUnit 9 (#1634)
 - Make `TestingFramework::isLoggedIn()` private (#1622)

--- a/Tests/Functional/Mapper/AbstractDataMapperTest.php
+++ b/Tests/Functional/Mapper/AbstractDataMapperTest.php
@@ -15,6 +15,7 @@ use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\ReadOnlyModel;
 use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\TestingChildModel;
 use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\TestingModel;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\DateTimeAspect;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -35,6 +36,9 @@ final class AbstractDataMapperTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        GeneralUtility::makeInstance(Context::class)
+            ->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('2018-04-26 12:42:23')));
 
         $this->subject = MapperRegistry::get(TestingMapper::class);
     }

--- a/Tests/Unit/Model/AbstractModelTest.php
+++ b/Tests/Unit/Model/AbstractModelTest.php
@@ -11,6 +11,7 @@ use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\ReadOnlyModel;
 use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\TestingChildModel;
 use OliverKlee\Oelib\Tests\Unit\Model\Fixtures\TestingModel;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\DateTimeAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -27,7 +28,8 @@ final class AbstractModelTest extends UnitTestCase
     {
         parent::setUp();
 
-        $GLOBALS['SIM_EXEC_TIME'] = 1_524_751_343;
+        GeneralUtility::makeInstance(Context::class)
+            ->setAspect('date', new DateTimeAspect(new \DateTimeImmutable('2018-04-26 12:42:23')));
 
         $this->subject = new TestingModel();
     }


### PR DESCRIPTION
This removes the last occurrence of `$GLOBALS['SIM_EXEC_TIME']`.

Fixes #1683