### PR TITLE
[TASK] Use the development PHP INI on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           coverage: none
       - name: "Show Composer version"
@@ -47,6 +48,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           extensions: zip
           coverage: none
@@ -90,6 +92,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2
       - name: "Show Composer version"
@@ -119,6 +122,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           extensions: zip
           coverage: none
@@ -221,6 +225,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           extensions: dom, json, libxml, mysqli, zip
           coverage: none


### PR DESCRIPTION
This will allow us to see (and error out on) all warnings and notices.

Fixes #1752