### PR TITLE
[TASK] Drop `approved="yes"` from the English locallang files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Drop `approved="yes"` from the English locallang files (#1894)
 - Drop unnecessary type checks (#1879)
 - Improve type annotations (#1871, #1880)
 - Drop obsolete options from the `ext_emconf.php` (#1814)

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -3,10 +3,10 @@
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>
-			<trans-unit id="label_test" resname="label_test" approved="yes">
+			<trans-unit id="label_test" resname="label_test">
 				<source>I am from file.</source>
 			</trans-unit>
-			<trans-unit id="validationError.fillInField" resname="validationError.fillInField" approved="yes">
+			<trans-unit id="validationError.fillInField" resname="validationError.fillInField">
 				<source>Please fill in this field.</source>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -3,19 +3,19 @@
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>
-			<trans-unit id="tx_oelib_domain_model_germanzipcode" resname="tx_oelib_domain_model_germanzipcode" approved="yes">
+			<trans-unit id="tx_oelib_domain_model_germanzipcode" resname="tx_oelib_domain_model_germanzipcode">
 				<source>German ZIP codes</source>
 			</trans-unit>
-			<trans-unit id="tx_oelib_domain_model_germanzipcode.zip_code" resname="tx_oelib_domain_model_germanzipcode.zip_code" approved="yes">
+			<trans-unit id="tx_oelib_domain_model_germanzipcode.zip_code" resname="tx_oelib_domain_model_germanzipcode.zip_code">
 				<source>ZIP code</source>
 			</trans-unit>
-			<trans-unit id="tx_oelib_domain_model_germanzipcode.city_name" resname="tx_oelib_domain_model_germanzipcode.city_name" approved="yes">
+			<trans-unit id="tx_oelib_domain_model_germanzipcode.city_name" resname="tx_oelib_domain_model_germanzipcode.city_name">
 				<source>City</source>
 			</trans-unit>
-			<trans-unit id="tx_oelib_domain_model_germanzipcode.longitude" resname="tx_oelib_domain_model_germanzipcode.longitude" approved="yes">
+			<trans-unit id="tx_oelib_domain_model_germanzipcode.longitude" resname="tx_oelib_domain_model_germanzipcode.longitude">
 				<source>Longitude</source>
 			</trans-unit>
-			<trans-unit id="tx_oelib_domain_model_germanzipcode.latitude" resname="tx_oelib_domain_model_germanzipcode.latitude" approved="yes">
+			<trans-unit id="tx_oelib_domain_model_germanzipcode.latitude" resname="tx_oelib_domain_model_germanzipcode.latitude">
 				<source>Latitude</source>
 			</trans-unit>
 		</body>


### PR DESCRIPTION
Approving only applies to translations, not to the original English labels.

Fixes #1783