### PR TITLE
[TASK] Remove the download counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![TYPO3 V11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
 [![TYPO3 V12](https://img.shields.io/badge/TYPO3-12-orange.svg)](https://get.typo3.org/version/12)
 [![License](https://img.shields.io/github/license/oliverklee/ext-oelib)](https://packagist.org/packages/oliverklee/oelib)
-[![Total Downloads](https://poser.pugx.org/oliverklee/oelib/downloads.svg)](https://packagist.org/packages/oliverklee/oelib)
 [![GitHub CI Status](https://github.com/oliverklee/ext-oelib/workflows/CI/badge.svg?branch=main)](https://github.com/oliverklee/ext-oelib/actions)
 [![Coverage Status](https://coveralls.io/repos/github/oliverklee/ext-oelib/badge.svg?branch=main)](https://coveralls.io/github/oliverklee/ext-oelib?branch=main)
 


### PR DESCRIPTION
The counter only shows the downloads on Packagist. For TYPO3 extensions, this is incomplete information and hence not really useful.

Fixes #1855

[ci skip]