### PR TITLE
[BUGFIX] Make implicit nullable parameter explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Make implicit nullable parameter explicit (#1962)
 - Add missing exception codes (#1945)
 - Improve some type annotations (#1929)
 

--- a/Classes/Mapper/AbstractDataMapper.php
+++ b/Classes/Mapper/AbstractDataMapper.php
@@ -1128,7 +1128,7 @@ abstract class AbstractDataMapper
     public function findAllByRelation(
         AbstractModel $model,
         string $relationKey,
-        Collection $ignoreList = null
+        ?Collection $ignoreList = null
     ): Collection {
         if (!$model->hasUid()) {
             throw new \InvalidArgumentException('$model must have a UID.', 1_331_319_915);


### PR DESCRIPTION
This removes a deprecation warning with PHP 8.4.

Fixes #1961