### PR TITLE
[FEATURE] Add `::getAsNonNegativeInteger()` and `::getAsPositiveInteg…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Add `::getAsNonNegativeInteger()` and `::getAsPositiveInteger()` (#1988)
 - Add support for PHP 8.4 (#1960)
 
 ### Changed

--- a/Classes/DataStructures/AbstractObjectWithPublicAccessors.php
+++ b/Classes/DataStructures/AbstractObjectWithPublicAccessors.php
@@ -81,6 +81,48 @@ abstract class AbstractObjectWithPublicAccessors extends AbstractObjectWithAcces
     }
 
     /**
+     * Gets the value stored in under the key $key, converted to an integer.
+     *
+     * @param non-empty-string $key
+     *
+     * @return int<0, max>
+     */
+    public function getAsNonNegativeInteger(string $key): int
+    {
+        $value = $this->getAsInteger($key);
+
+        if ($value < 0) {
+            throw new \UnexpectedValueException(
+                'The value for the key "' . $key . '" must be a non-negative integer, but it is ' . $value . '.',
+                1735299608
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Gets the value stored in under the key $key, converted to an integer.
+     *
+     * @param non-empty-string $key
+     *
+     * @return positive-int
+     */
+    public function getAsPositiveInteger(string $key): int
+    {
+        $value = $this->getAsInteger($key);
+
+        if ($value <= 0) {
+            throw new \UnexpectedValueException(
+                'The value for the key "' . $key . '" must be a positive integer, but it is ' . $value . '.',
+                1735299700
+            );
+        }
+
+        return $value;
+    }
+
+    /**
      * Gets the value stored under the provided key, converted to an array of trimmed strings.
      *
      * @param non-empty-string $key

--- a/Tests/Unit/DataStructures/AbstractObjectWithPublicAccessorsTest.php
+++ b/Tests/Unit/DataStructures/AbstractObjectWithPublicAccessorsTest.php
@@ -162,6 +162,32 @@ final class AbstractObjectWithPublicAccessorsTest extends UnitTestCase
     /**
      * @test
      */
+    public function getAsNonNegativeIntegerWithEmptyKeyThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$key must not be empty.');
+        $this->expectExceptionCode(1_331_488_963);
+
+        // @phpstan-ignore-next-line We are explicitly checking for a contract violation here.
+        $this->subject->getAsNonNegativeInteger('');
+    }
+
+    /**
+     * @test
+     */
+    public function getAsPositiveIntegerWithEmptyKeyThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$key must not be empty.');
+        $this->expectExceptionCode(1_331_488_963);
+
+        // @phpstan-ignore-next-line We are explicitly checking for a contract violation here.
+        $this->subject->getAsPositiveInteger('');
+    }
+
+    /**
+     * @test
+     */
     public function getAsIntegerWithInexistentKeyReturnsZero(): void
     {
         self::assertSame(0, $this->subject->getAsInteger('foo'));
@@ -196,6 +222,109 @@ final class AbstractObjectWithPublicAccessorsTest extends UnitTestCase
         $this->subject->setData([$key => $inputValue]);
 
         self::assertSame($expected, $this->subject->getAsInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsNonNegativeIntegerForZeroReturnsSetValue(): void
+    {
+        $key = 'foo';
+        $value = 0;
+        $this->subject->setData([$key => $value]);
+
+        self::assertSame($value, $this->subject->getAsNonNegativeInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsNonNegativeIntegerForPositiveValueReturnsSetValue(): void
+    {
+        $key = 'foo';
+        $value = 1;
+        $this->subject->setData([$key => $value]);
+
+        self::assertSame($value, $this->subject->getAsNonNegativeInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsNonNegativeIntegerForPositiveStringValueReturnsSetIntegerValue(): void
+    {
+        $key = 'foo';
+        $this->subject->setData([$key => '2']);
+
+        self::assertSame(2, $this->subject->getAsNonNegativeInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsNonNegativeIntegerForNegativeValueThrowsException(): void
+    {
+        $key = 'foo';
+        $this->subject->setData([$key => -1]);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The value for the key "foo" must be a non-negative integer, but it is -1.');
+        $this->expectExceptionCode(1735299608);
+
+        $this->subject->getAsNonNegativeInteger($key);
+    }
+
+    /**
+     * @test
+     */
+    public function getAsPositiveIntegerForPositiveIntegerValueReturnsSetValue(): void
+    {
+        $key = 'foo';
+        $value = 1;
+        $this->subject->setData([$key => $value]);
+
+        self::assertSame($value, $this->subject->getAsPositiveInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsPositiveIntegerForPositiveStringValueReturnsSetIntegerValue(): void
+    {
+        $key = 'foo';
+        $this->subject->setData([$key => '2']);
+
+        self::assertSame(2, $this->subject->getAsPositiveInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsPositiveIntegerForZeroThrowsException(): void
+    {
+        $key = 'foo';
+        $this->subject->setData([$key => 0]);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The value for the key "foo" must be a positive integer, but it is 0');
+        $this->expectExceptionCode(1735299700);
+
+        $this->subject->getAsPositiveInteger($key);
+    }
+
+    /**
+     * @test
+     */
+    public function getAsPositiveIntegerForNegativeValueThrowsException(): void
+    {
+        $key = 'foo';
+        $this->subject->setData([$key => -1]);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The value for the key "foo" must be a positive integer, but it is -1.');
+        $this->expectExceptionCode(1735299700);
+
+        $this->subject->getAsPositiveInteger($key);
     }
 
     /**


### PR DESCRIPTION
…er()`

This helps with type safety.

Fixes #1452