### PR TITLE
[BUGFIX] Move `getAs*Integer` to the correct superclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Move `getAs*Integer` to the correct superclass (#2009)
 - Improve some type annotations and PHPDoc comments (#2008)
 
 ## 6.1.0: Add support for PHP 8.4

--- a/Classes/DataStructures/AbstractObjectWithPublicAccessors.php
+++ b/Classes/DataStructures/AbstractObjectWithPublicAccessors.php
@@ -80,16 +80,7 @@ abstract class AbstractObjectWithPublicAccessors extends AbstractObjectWithAcces
      */
     public function getAsNonNegativeInteger(string $key): int
     {
-        $value = $this->getAsInteger($key);
-
-        if ($value < 0) {
-            throw new \UnexpectedValueException(
-                'The value for the key "' . $key . '" must be a non-negative integer, but it is ' . $value . '.',
-                1735299608
-            );
-        }
-
-        return $value;
+        return parent::getAsNonNegativeInteger($key);
     }
 
     /**
@@ -101,16 +92,7 @@ abstract class AbstractObjectWithPublicAccessors extends AbstractObjectWithAcces
      */
     public function getAsPositiveInteger(string $key): int
     {
-        $value = $this->getAsInteger($key);
-
-        if ($value <= 0) {
-            throw new \UnexpectedValueException(
-                'The value for the key "' . $key . '" must be a positive integer, but it is ' . $value . '.',
-                1735299700
-            );
-        }
-
-        return $value;
+        return parent::getAsPositiveInteger($key);
     }
 
     /**

--- a/Classes/DataStructures/AbstractReadOnlyObjectWithAccessors.php
+++ b/Classes/DataStructures/AbstractReadOnlyObjectWithAccessors.php
@@ -80,6 +80,48 @@ abstract class AbstractReadOnlyObjectWithAccessors
     }
 
     /**
+     * Gets the value stored under the given key, converted to an integer.
+     *
+     * @param non-empty-string $key
+     *
+     * @return int<0, max>
+     */
+    protected function getAsNonNegativeInteger(string $key): int
+    {
+        $value = $this->getAsInteger($key);
+
+        if ($value < 0) {
+            throw new \UnexpectedValueException(
+                'The value for the key "' . $key . '" must be a non-negative integer, but it is ' . $value . '.',
+                1735299608
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Gets the value stored under the given key, converted to an integer.
+     *
+     * @param non-empty-string $key
+     *
+     * @return positive-int
+     */
+    protected function getAsPositiveInteger(string $key): int
+    {
+        $value = $this->getAsInteger($key);
+
+        if ($value <= 0) {
+            throw new \UnexpectedValueException(
+                'The value for the key "' . $key . '" must be a positive integer, but it is ' . $value . '.',
+                1735299700
+            );
+        }
+
+        return $value;
+    }
+
+    /**
      * Gets the value stored under the provided key, converted to an array of trimmed strings.
      *
      * @param non-empty-string $key

--- a/Classes/DataStructures/AbstractReadOnlyObjectWithPublicAccessors.php
+++ b/Classes/DataStructures/AbstractReadOnlyObjectWithPublicAccessors.php
@@ -50,6 +50,30 @@ abstract class AbstractReadOnlyObjectWithPublicAccessors extends AbstractReadOnl
     }
 
     /**
+     * Gets the value stored under the given key, converted to an integer.
+     *
+     * @param non-empty-string $key
+     *
+     * @return int<0, max>
+     */
+    public function getAsNonNegativeInteger(string $key): int
+    {
+        return parent::getAsNonNegativeInteger($key);
+    }
+
+    /**
+     * Gets the value stored under the given key, converted to an integer.
+     *
+     * @param non-empty-string $key
+     *
+     * @return positive-int
+     */
+    public function getAsPositiveInteger(string $key): int
+    {
+        return parent::getAsPositiveInteger($key);
+    }
+
+    /**
      * Gets the value stored under the provided key, converted to an array of trimmed strings.
      *
      * @param non-empty-string $key

--- a/Tests/Unit/DataStructures/AbstractReadOnlyObjectWithAccessorsTest.php
+++ b/Tests/Unit/DataStructures/AbstractReadOnlyObjectWithAccessorsTest.php
@@ -160,6 +160,135 @@ final class AbstractReadOnlyObjectWithAccessorsTest extends UnitTestCase
     /**
      * @test
      */
+    public function getAsNonNegativeIntegerWithEmptyKeyThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$key must not be empty.');
+        $this->expectExceptionCode(1_331_488_963);
+
+        // @phpstan-ignore-next-line We are explicitly checking for a contract violation here.
+        $this->subject->getAsNonNegativeInteger('');
+    }
+
+    /**
+     * @test
+     */
+    public function getAsPositiveIntegerWithEmptyKeyThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$key must not be empty.');
+        $this->expectExceptionCode(1_331_488_963);
+
+        // @phpstan-ignore-next-line We are explicitly checking for a contract violation here.
+        $this->subject->getAsPositiveInteger('');
+    }
+
+    /**
+     * @test
+     */
+    public function getAsNonNegativeIntegerForZeroReturnsSetValue(): void
+    {
+        $key = 'foo';
+        $value = 0;
+        $this->subject->setData([$key => $value]);
+
+        self::assertSame($value, $this->subject->getAsNonNegativeInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsNonNegativeIntegerForPositiveValueReturnsSetValue(): void
+    {
+        $key = 'foo';
+        $value = 1;
+        $this->subject->setData([$key => $value]);
+
+        self::assertSame($value, $this->subject->getAsNonNegativeInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsNonNegativeIntegerForPositiveStringValueReturnsSetIntegerValue(): void
+    {
+        $key = 'foo';
+        $this->subject->setData([$key => '2']);
+
+        self::assertSame(2, $this->subject->getAsNonNegativeInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsNonNegativeIntegerForNegativeValueThrowsException(): void
+    {
+        $key = 'foo';
+        $this->subject->setData([$key => -1]);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The value for the key "foo" must be a non-negative integer, but it is -1.');
+        $this->expectExceptionCode(1735299608);
+
+        $this->subject->getAsNonNegativeInteger($key);
+    }
+
+    /**
+     * @test
+     */
+    public function getAsPositiveIntegerForPositiveIntegerValueReturnsSetValue(): void
+    {
+        $key = 'foo';
+        $value = 1;
+        $this->subject->setData([$key => $value]);
+
+        self::assertSame($value, $this->subject->getAsPositiveInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsPositiveIntegerForPositiveStringValueReturnsSetIntegerValue(): void
+    {
+        $key = 'foo';
+        $this->subject->setData([$key => '2']);
+
+        self::assertSame(2, $this->subject->getAsPositiveInteger($key));
+    }
+
+    /**
+     * @test
+     */
+    public function getAsPositiveIntegerForZeroThrowsException(): void
+    {
+        $key = 'foo';
+        $this->subject->setData([$key => 0]);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The value for the key "foo" must be a positive integer, but it is 0');
+        $this->expectExceptionCode(1735299700);
+
+        $this->subject->getAsPositiveInteger($key);
+    }
+
+    /**
+     * @test
+     */
+    public function getAsPositiveIntegerForNegativeValueThrowsException(): void
+    {
+        $key = 'foo';
+        $this->subject->setData([$key => -1]);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The value for the key "foo" must be a positive integer, but it is -1.');
+        $this->expectExceptionCode(1735299700);
+
+        $this->subject->getAsPositiveInteger($key);
+    }
+
+    /**
+     * @test
+     */
     public function getAsTrimmedArrayWithEmptyKeyThrowsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
Follow up to #1988
Part of #2007