### PR TITLE
[TASK] Drop the mm tables from `ext_tables.sql`

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -40,16 +40,3 @@ CREATE TABLE tx_oelib_testchild (
     tx_oelib_parent2 int(11) unsigned DEFAULT '0' NOT NULL,
     tx_oelib_parent3 int(11) unsigned DEFAULT '0' NOT NULL
 );
-
-
-#
-# Table structure for table 'tx_oelib_test_article_mm'
-#
-CREATE TABLE tx_oelib_test_article_mm (
-    uid_local int(11) unsigned DEFAULT '0' NOT NULL,
-    uid_foreign int(11) unsigned DEFAULT '0' NOT NULL,
-    sorting int(11) unsigned DEFAULT '0' NOT NULL,
-
-    KEY uid_local (uid_local),
-    KEY uid_foreign (uid_foreign)
-);


### PR DESCRIPTION
Nowadays, the Core auto-generates these tables.