### PR TITLE
[TASK] Switch the indentation of XLIFF files to 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,7 +48,7 @@ indent_size = 2
 
 # XLF-Files
 [*.xlf]
-indent_style = tab
+indent_size = 2
 
 # SQL-Files
 [*.sql]

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" datatype="plaintext" original="messages">
-		<header/>
-		<body>
-			<trans-unit id="label_test">
-				<source>I am from file.</source>
-			</trans-unit>
-			<trans-unit id="validationError.fillInField">
-				<source>Please fill in this field.</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file source-language="en" datatype="plaintext" original="messages">
+    <header/>
+    <body>
+      <trans-unit id="label_test">
+        <source>I am from file.</source>
+      </trans-unit>
+      <trans-unit id="validationError.fillInField">
+        <source>Please fill in this field.</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" datatype="plaintext" original="messages">
-		<header/>
-		<body>
-			<trans-unit id="tx_oelib_domain_model_germanzipcode">
-				<source>German ZIP codes</source>
-			</trans-unit>
-			<trans-unit id="tx_oelib_domain_model_germanzipcode.zip_code">
-				<source>ZIP code</source>
-			</trans-unit>
-			<trans-unit id="tx_oelib_domain_model_germanzipcode.city_name">
-				<source>City</source>
-			</trans-unit>
-			<trans-unit id="tx_oelib_domain_model_germanzipcode.longitude">
-				<source>Longitude</source>
-			</trans-unit>
-			<trans-unit id="tx_oelib_domain_model_germanzipcode.latitude">
-				<source>Latitude</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file source-language="en" datatype="plaintext" original="messages">
+    <header/>
+    <body>
+      <trans-unit id="tx_oelib_domain_model_germanzipcode">
+        <source>German ZIP codes</source>
+      </trans-unit>
+      <trans-unit id="tx_oelib_domain_model_germanzipcode.zip_code">
+        <source>ZIP code</source>
+      </trans-unit>
+      <trans-unit id="tx_oelib_domain_model_germanzipcode.city_name">
+        <source>City</source>
+      </trans-unit>
+      <trans-unit id="tx_oelib_domain_model_germanzipcode.longitude">
+        <source>Longitude</source>
+      </trans-unit>
+      <trans-unit id="tx_oelib_domain_model_germanzipcode.latitude">
+        <source>Latitude</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>


### PR DESCRIPTION
This follows recent changes in the TYPO3 Core:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/91368

Fixes #2139