### PR TITLE
[TASK] Adapt links to the moved repositories

### DIFF
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -5,8 +5,8 @@
     <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
                project-home="https://extensions.typo3.org/extension/oelib"
                project-contact="mailto:typo3-coding@oliverklee.de"
-               project-repository="https://github.com/oliverklee/ext-oelib"
-               project-issues="https://github.com/oliverklee/ext-oelib/issues" edit-on-github-branch="main"
+               project-repository="https://github.com/oliverklee-de/oelib"
+               project-issues="https://github.com/oliverklee-de/oelib/issues" edit-on-github-branch="main"
                edit-on-github="oliverklee/ext-oelib" typo3-core-preferred="stable"
                interlink-shortcode="oliverklee/oelib"/>
     <project title="oelib" release="6.2.0" version="6.2" copyright="2026"/>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![TYPO3 V11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
 [![TYPO3 V12](https://img.shields.io/badge/TYPO3-12-orange.svg)](https://get.typo3.org/version/12)
-[![License](https://img.shields.io/github/license/oliverklee/ext-oelib)](https://packagist.org/packages/oliverklee/oelib)
-[![GitHub CI Status](https://github.com/oliverklee/ext-oelib/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/oliverklee/ext-oelib/actions)
-[![Coverage Status](https://coveralls.io/repos/github/oliverklee/ext-oelib/badge.svg?branch=main)](https://coveralls.io/github/oliverklee/ext-oelib?branch=main)
+[![License](https://img.shields.io/github/license/oliverklee-de/oelib)](https://packagist.org/packages/oliverklee/oelib)
+[![GitHub CI Status](https://github.com/oliverklee-de/oelib/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/oliverklee-de/oelib/actions)
+[![Coverage Status](https://coveralls.io/repos/github/oliverklee-de/oelib/badge.svg?branch=main)](https://coveralls.io/github/oliverklee-de/oelib?branch=main)
 
 This extension provides useful stuff for extension development: helper functions
 for unit testing, templating and

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
 	],
 	"homepage": "https://www.oliverklee.de/typo3-services/typo3-extensions/",
 	"support": {
-		"issues": "https://github.com/oliverklee/ext-oelib/issues",
-		"source": "https://github.com/oliverklee/ext-oelib"
+		"issues": "https://github.com/oliverklee-de/oelib/issues",
+		"source": "https://github.com/oliverklee-de/oelib"
 	},
 	"require": {
 		"php": "^7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",


### PR DESCRIPTION
This repository was moved to a GitHub organization. Hence we need to adapt all corresponding links.