### PR TITLE
[CLEANUP] Do not quote numeric default values in `ext_tables.sql`

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,31 +1,33 @@
-CREATE TABLE tx_oelib_domain_model_germanzipcode (
-	zip_code  varchar(5)    DEFAULT ''         NOT NULL,
-	city_name varchar(255)  DEFAULT ''         NOT NULL,
-	longitude decimal(9, 6) DEFAULT '0.000000' NOT NULL,
-	latitude  decimal(9, 6) DEFAULT '0.000000' NOT NULL
+CREATE TABLE tx_oelib_domain_model_germanzipcode
+(
+	zip_code  varchar(5)    DEFAULT ''  NOT NULL,
+	city_name varchar(255)  DEFAULT ''  NOT NULL,
+	longitude decimal(9, 6) DEFAULT 0.0 NOT NULL,
+	latitude  decimal(9, 6) DEFAULT 0.0 NOT NULL
 );
 
 #
 # Table structure for table 'tx_oelib_test'
 #
-CREATE TABLE tx_oelib_test (
-	object_type                 int(11) unsigned    DEFAULT '0'        NOT NULL,
-	title                       varchar(255)        DEFAULT ''         NOT NULL,
-	friend                      int(11) unsigned    DEFAULT '0'        NOT NULL,
-	owner                       int(11) unsigned    DEFAULT '0'        NOT NULL,
-	children                    varchar(255)        DEFAULT ''         NOT NULL,
-	related_records             int(11) unsigned    DEFAULT '0'        NOT NULL,
-	bidirectional               int(11) unsigned    DEFAULT '0'        NOT NULL,
-	composition                 int(11) unsigned    DEFAULT '0'        NOT NULL,
-	composition2                int(11) unsigned    DEFAULT '0'        NOT NULL,
-	composition_without_sorting int(11) unsigned    DEFAULT '0'        NOT NULL,
-	float_data                  float(9, 6)         DEFAULT '0.000000' NOT NULL,
-	decimal_data                decimal(10, 3)      DEFAULT '0.000'    NOT NULL,
-	string_data                 varchar(255)        DEFAULT ''         NOT NULL,
-	header                      varchar(255)        DEFAULT ''         NOT NULL,
-	bool_data1                  tinyint(1) unsigned DEFAULT '0'        NOT NULL,
-	bool_data2                  tinyint(1) unsigned DEFAULT '0'        NOT NULL,
-	int_data                    tinyint(4) unsigned DEFAULT '0'        NOT NULL,
+CREATE TABLE tx_oelib_test
+(
+	object_type                 int(11) unsigned    DEFAULT 0        NOT NULL,
+	title                       varchar(255)        DEFAULT ''       NOT NULL,
+	friend                      int(11) unsigned    DEFAULT 0        NOT NULL,
+	owner                       int(11) unsigned    DEFAULT 0        NOT NULL,
+	children                    varchar(255)        DEFAULT ''       NOT NULL,
+	related_records             int(11) unsigned    DEFAULT 0        NOT NULL,
+	bidirectional               int(11) unsigned    DEFAULT 0        NOT NULL,
+	composition                 int(11) unsigned    DEFAULT 0        NOT NULL,
+	composition2                int(11) unsigned    DEFAULT 0        NOT NULL,
+	composition_without_sorting int(11) unsigned    DEFAULT 0        NOT NULL,
+	float_data                  float(9, 6)         DEFAULT 0.0      NOT NULL,
+	decimal_data                decimal(10, 3)      DEFAULT 0.0      NOT NULL,
+	string_data                 varchar(255)        DEFAULT ''       NOT NULL,
+	header                      varchar(255)        DEFAULT ''       NOT NULL,
+	bool_data1                  tinyint(1) unsigned DEFAULT 0        NOT NULL,
+	bool_data2                  tinyint(1) unsigned DEFAULT 0        NOT NULL,
+	int_data                    tinyint(4) unsigned DEFAULT 0        NOT NULL,
 
 	KEY object_type(object_type)
 );
@@ -34,9 +36,10 @@ CREATE TABLE tx_oelib_test (
 #
 # Table structure for table 'tx_oelib_testchild'
 #
-CREATE TABLE tx_oelib_testchild (
-	title            varchar(255)     DEFAULT ''  NOT NULL,
-	parent           int(11) unsigned DEFAULT '0' NOT NULL,
-	tx_oelib_parent2 int(11) unsigned DEFAULT '0' NOT NULL,
-	tx_oelib_parent3 int(11) unsigned DEFAULT '0' NOT NULL
+CREATE TABLE tx_oelib_testchild
+(
+	title            varchar(255)     DEFAULT '' NOT NULL,
+	parent           int(11) unsigned DEFAULT 0  NOT NULL,
+	tx_oelib_parent2 int(11) unsigned DEFAULT 0  NOT NULL,
+	tx_oelib_parent3 int(11) unsigned DEFAULT 0  NOT NULL
 );


### PR DESCRIPTION
For numeric columns, there is no point in string-quoting the default value.

Fixes #2145