### PR TITLE
[TASK] Require the latest TYPO3 security release for 12LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Require the latest TYPO3 12LTS security release (#2076)
+- Require the latest TYPO3 12LTS security release (#2076, #2161)
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
 		"doctrine/dbal": "^2.13.8 || ^3.9",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",
 		"symfony/polyfill-php80": "^1.31.0",
-		"typo3/cms-core": "^11.5.41 || ^12.4.31",
-		"typo3/cms-extbase": "^11.5.41 || ^12.4.31",
-		"typo3/cms-fluid": "^11.5.41 || ^12.4.31",
-		"typo3/cms-frontend": "^11.5.41 || ^12.4.31",
+		"typo3/cms-core": "^11.5.41 || ^12.4.41",
+		"typo3/cms-extbase": "^11.5.41 || ^12.4.41",
+		"typo3/cms-fluid": "^11.5.41 || ^12.4.41",
+		"typo3/cms-frontend": "^11.5.41 || ^12.4.41",
 		"typo3fluid/fluid": "^2.7.4 || ^4.0.2"
 	},
 	"require-dev": {


### PR DESCRIPTION
This only affects installations using TYPO3 12LTS. Installations on TYPO3 11LTS are not affected.

Fixes #2106