### PR TITLE
[TASK] Provide the `ConnectionPool` via DI to `PageRepository`

### DIFF
--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -6,9 +6,7 @@ namespace OliverKlee\Oelib\Domain\Repository;
 
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\SingletonInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Repository for finding page records by UID.
@@ -17,6 +15,13 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class PageRepository implements SingletonInterface
 {
+    private ConnectionPool $connectionPool;
+
+    public function __construct(ConnectionPool $connectionPool)
+    {
+        $this->connectionPool = $connectionPool;
+    }
+
     /**
      * Recursively finds all pages within the given page, and returns them as a sorted list (including the provided
      * parent pages).
@@ -81,7 +86,7 @@ class PageRepository implements SingletonInterface
      */
     private function findDirectSubpages(array $pageUids): array
     {
-        $queryBuilder = $this->getQueryBuilderForTable('pages');
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
         $query = $queryBuilder->select('uid')->from('pages');
         $query->andWhere(
             $query->expr()->in('pid', $queryBuilder->createNamedParameter($pageUids, Connection::PARAM_INT_ARRAY)),
@@ -95,18 +100,5 @@ class PageRepository implements SingletonInterface
         }
 
         return $subpageUids;
-    }
-
-    /**
-     * @param non-empty-string $tableName
-     */
-    private function getQueryBuilderForTable(string $tableName): QueryBuilder
-    {
-        return $this->getConnectionPool()->getQueryBuilderForTable($tableName);
-    }
-
-    private function getConnectionPool(): ConnectionPool
-    {
-        return GeneralUtility::makeInstance(ConnectionPool::class);
     }
 }

--- a/Tests/Functional/Domain/Repository/PageRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/PageRepositoryTest.php
@@ -21,7 +21,8 @@ final class PageRepositoryTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->subject = new PageRepository();
+        $this->subject = $this->get(PageRepository::class);
+
         $this->importCSVDataSet(__DIR__ . '/Fixtures/NestedPages.csv');
     }
 


### PR DESCRIPTION
We then also need to use the DI container (via `$this->get()`)
in the functional tests to get the dependencies injected.

This unblocks the `ssch/typo3-rector` update. (The new version
will do this kind of change.)
