### PR TITLE
[TASK] Reduce the PHP_CodeSniffer ruleset

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset name="phpList Coding Standard">
-    <description>
-        This standard requires PHP_CodeSniffer >= 3.5.2.
-    </description>
-
+<ruleset name="oliverklee.de">
     <arg name="colors"/>
     <arg name="extensions" value="php"/>
 
-    <!-- The complete PSR-12 ruleset -->
-    <rule ref="PSR12"/>
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120"/>
+            <property name="absoluteLineLimit" value="120"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.PHP.Heredoc"/>
 </ruleset>


### PR DESCRIPTION
Nowadays, PHP-CS-Fixer covers most of our code style checking needs. So we should only have those rules in the PHP_CodeSniffer configuration that are not covered by PHP-CS-Fixer.

This gets rid of the hassle of resolving rule conflicts between the two tools.

Also fix some copy'n'paste in the ruleset name.

Fixes #2104