### PR TITLE
[BUGFIX] Load all required core extensions in the functionals

### DIFF
--- a/Tests/Functional/Mapper/CountryMapperTest.php
+++ b/Tests/Functional/Mapper/CountryMapperTest.php
@@ -16,6 +16,8 @@ final class CountryMapperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = ['oliverklee/oelib', 'sjbr/static-info-tables'];
 
+    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+
     private CountryMapper $subject;
 
     protected function setUp(): void

--- a/Tests/Functional/Mapper/CurrencyMapperTest.php
+++ b/Tests/Functional/Mapper/CurrencyMapperTest.php
@@ -16,6 +16,8 @@ final class CurrencyMapperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = ['oliverklee/oelib', 'sjbr/static-info-tables'];
 
+    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+
     private CurrencyMapper $subject;
 
     protected function setUp(): void

--- a/Tests/Functional/Mapper/LanguageMapperTest.php
+++ b/Tests/Functional/Mapper/LanguageMapperTest.php
@@ -16,6 +16,8 @@ final class LanguageMapperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = ['oliverklee/oelib', 'sjbr/static-info-tables'];
 
+    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+
     private LanguageMapper $subject;
 
     protected function setUp(): void

--- a/Tests/Functional/ViewHelpers/PriceViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/PriceViewHelperTest.php
@@ -14,6 +14,8 @@ class PriceViewHelperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = ['oliverklee/oelib', 'sjbr/static-info-tables'];
 
+    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+
     private PriceViewHelper $subject;
 
     protected function setUp(): void

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
 		"symfony/console": "5.4.47 || 6.4.32 || 7.4.4",
 		"symfony/translation": "5.4.45 || 6.4.32 || 7.4.4",
 		"symfony/yaml": "5.4.45 || 6.4.30 || 7.4.1",
+		"typo3/cms-install": "^11.5 || ^12.4",
 		"typo3/coding-standards": "0.6.1 || 0.8.0",
 		"typo3/testing-framework": "7.1.1",
 		"webmozart/assert": "^1.12.1 || ^2.1.5"


### PR DESCRIPTION
The `static_info_tables` has a dependency on `typo3/cms-install`. So whenever we load `static_info_tables` in a functional test, we also need to load `typo3/cms-install`.

This also means that we need to add `typo3/cms-install` as a development dependency.

Note: This can all go away once we've dropped the deprecated classes and with them the dependency on `static_info_tables`.