### PR TITLE
[BUGFIX] Load the correct static_info_tables dependency

### DIFF
--- a/Tests/Functional/Mapper/CountryMapperTest.php
+++ b/Tests/Functional/Mapper/CountryMapperTest.php
@@ -16,7 +16,7 @@ final class CountryMapperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = ['oliverklee/oelib', 'sjbr/static-info-tables'];
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+    protected array $coreExtensionsToLoad = ['typo3/cms-extensionmanager'];
 
     private CountryMapper $subject;
 

--- a/Tests/Functional/Mapper/CurrencyMapperTest.php
+++ b/Tests/Functional/Mapper/CurrencyMapperTest.php
@@ -16,7 +16,7 @@ final class CurrencyMapperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = ['oliverklee/oelib', 'sjbr/static-info-tables'];
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+    protected array $coreExtensionsToLoad = ['typo3/cms-extensionmanager'];
 
     private CurrencyMapper $subject;
 

--- a/Tests/Functional/Mapper/LanguageMapperTest.php
+++ b/Tests/Functional/Mapper/LanguageMapperTest.php
@@ -16,7 +16,7 @@ final class LanguageMapperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = ['oliverklee/oelib', 'sjbr/static-info-tables'];
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+    protected array $coreExtensionsToLoad = ['typo3/cms-extensionmanager'];
 
     private LanguageMapper $subject;
 

--- a/Tests/Functional/ViewHelpers/PriceViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/PriceViewHelperTest.php
@@ -14,7 +14,7 @@ class PriceViewHelperTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = ['oliverklee/oelib', 'sjbr/static-info-tables'];
 
-    protected array $coreExtensionsToLoad = ['typo3/cms-install'];
+    protected array $coreExtensionsToLoad = ['typo3/cms-extensionmanager'];
 
     private PriceViewHelper $subject;
 

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
 		"symfony/console": "5.4.47 || 6.4.32 || 7.4.4",
 		"symfony/translation": "5.4.45 || 6.4.32 || 7.4.4",
 		"symfony/yaml": "5.4.45 || 6.4.30 || 7.4.1",
-		"typo3/cms-install": "^11.5 || ^12.4",
+		"typo3/cms-extensionmanager": "^11.5 || ^12.4",
 		"typo3/coding-standards": "0.6.1 || 0.8.0",
 		"typo3/testing-framework": "7.1.1",
 		"webmozart/assert": "^1.12.1 || ^2.1.5"


### PR DESCRIPTION
`sjbr/static-info-tables` depends on
`typo3/cms-extensionmanager`, not on `typo3/cms-install`.

Reflect that in the functional tests and add
`typo3/cms-extensionmanager` as a development dependency.

Followup to #2184