### PR TITLE
[BUGFIX] Avoid polluting the global state in the unit tests

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -467,7 +467,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'oelib' on mixed\\.$#"
-			count: 3
+			count: 2
 			path: ../../Tests/Unit/Configuration/ConfigurationProxyTest.php
 
 		-
@@ -487,17 +487,17 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'MAIL' on mixed\\.$#"
-			count: 14
+			count: 16
 			path: ../../Tests/Unit/Email/SystemEmailFromBuilderTest.php
 
 		-
 			message: "#^Cannot access offset 'defaultMailFromAddr…' on mixed\\.$#"
-			count: 7
+			count: 8
 			path: ../../Tests/Unit/Email/SystemEmailFromBuilderTest.php
 
 		-
 			message: "#^Cannot access offset 'defaultMailFromName' on mixed\\.$#"
-			count: 7
+			count: 8
 			path: ../../Tests/Unit/Email/SystemEmailFromBuilderTest.php
 
 		-
@@ -546,14 +546,9 @@ parameters:
 			path: ../../Tests/Unit/Model/AbstractModelTest.php
 
 		-
-			message: "#^Cannot access offset 'fe_users' on mixed\\.$#"
-			count: 2
-			path: ../../Tests/Unit/Model/FrontEndUserTest.php
-
-		-
-			message: "#^Property OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Model\\\\FrontEndUserTest\\:\\:\\$tcaBackup \\(array\\<string, mixed\\>\\) does not accept mixed\\.$#"
+			message: "#^Cannot access offset 'EXTCONF' on mixed\\.$#"
 			count: 1
-			path: ../../Tests/Unit/Model/FrontEndUserTest.php
+			path: ../../Tests/Unit/Testing/TestingFrameworkTest.php
 
 		-
 			message: "#^Cannot access an offset on mixed\\.$#"

--- a/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
+++ b/Tests/Unit/Configuration/AbstractConfigurationCheckTest.php
@@ -19,7 +19,8 @@ final class AbstractConfigurationCheckTest extends UnitTestCase
     protected function tearDown(): void
     {
         ConfigurationProxy::purgeInstances();
-        unset($GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromAddress'], $GLOBALS['BE_USER']);
+        $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromAddress'] = '';
+        unset($GLOBALS['BE_USER']);
 
         parent::tearDown();
     }

--- a/Tests/Unit/Configuration/ConfigurationProxyTest.php
+++ b/Tests/Unit/Configuration/ConfigurationProxyTest.php
@@ -44,7 +44,7 @@ final class ConfigurationProxyTest extends UnitTestCase
 
     protected function tearDown(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['oelib'] = [];
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'] = [];
         ConfigurationProxy::purgeInstances();
         parent::tearDown();
     }

--- a/Tests/Unit/Email/SystemEmailFromBuilderTest.php
+++ b/Tests/Unit/Email/SystemEmailFromBuilderTest.php
@@ -22,6 +22,14 @@ final class SystemEmailFromBuilderTest extends UnitTestCase
         $this->subject = new SystemEmailFromBuilder();
     }
 
+    protected function tearDown(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromAddress'] = '';
+        $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromName'] = '';
+
+        parent::tearDown();
+    }
+
     /**
      * @test
      */

--- a/Tests/Unit/Model/FrontEndUserTest.php
+++ b/Tests/Unit/Model/FrontEndUserTest.php
@@ -19,24 +19,18 @@ final class FrontEndUserTest extends UnitTestCase
 {
     private FrontEndUser $subject;
 
-    /**
-     * @var array<string, mixed>
-     */
-    private $tcaBackup = [];
-
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->subject = new FrontEndUser();
-
-        $this->tcaBackup = $GLOBALS['TCA']['fe_users'] ?? [];
     }
 
     protected function tearDown(): void
     {
+        unset($GLOBALS['TCA']);
+
         parent::tearDown();
-        $GLOBALS['TCA']['fe_users'] = $this->tcaBackup;
     }
 
     /**

--- a/Tests/Unit/Testing/TestingFrameworkTest.php
+++ b/Tests/Unit/Testing/TestingFrameworkTest.php
@@ -31,6 +31,8 @@ final class TestingFrameworkTest extends UnitTestCase
 
         GeneralUtility::purgeInstances();
 
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']);
+
         parent::tearDown();
     }
 


### PR DESCRIPTION
This change unfortunately introduces some new PHPStan warnings, which will be cleaned up later.