### PR TITLE
[CLEANUP] Drop `@doesNotPerformAssertions` annotation

### DIFF
--- a/Tests/Functional/Mapper/AbstractDataMapperTest.php
+++ b/Tests/Functional/Mapper/AbstractDataMapperTest.php
@@ -1607,7 +1607,6 @@ final class AbstractDataMapperTest extends FunctionalTestCase
 
     /**
      * @test
-     * @doesNotPerformAssertions
      */
     public function silentlyIgnoresCommaSeparatedOneToManyRelationWithZeroForeignUid(): void
     {
@@ -1651,7 +1650,6 @@ final class AbstractDataMapperTest extends FunctionalTestCase
 
     /**
      * @test
-     * @doesNotPerformAssertions
      */
     public function silentlyIgnoresManyToManyRelationWithZeroForeignUid(): void
     {
@@ -3116,8 +3114,6 @@ final class AbstractDataMapperTest extends FunctionalTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function deleteForDeadModelDoesNotThrowException(): void
     {
@@ -3258,8 +3254,6 @@ final class AbstractDataMapperTest extends FunctionalTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function deleteForDirtyModelWithOneToManyRelationToDirtyElementDoesNotCrash(): void
     {

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -1529,8 +1529,6 @@ final class TestingFrameworkTest extends FunctionalTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function logoutFrontEndUserCanBeCalledTwoTimes(): void
     {

--- a/Tests/Unit/Configuration/ConfigurationRegistryTest.php
+++ b/Tests/Unit/Configuration/ConfigurationRegistryTest.php
@@ -109,8 +109,6 @@ final class ConfigurationRegistryTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function setTwoTimesForTheSameNamespaceDoesNotFail(): void
     {

--- a/Tests/Unit/Configuration/TypoScriptConfigurationTest.php
+++ b/Tests/Unit/Configuration/TypoScriptConfigurationTest.php
@@ -53,8 +53,6 @@ final class TypoScriptConfigurationTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function setDataWithEmptyArrayIsAllowed(): void
     {
@@ -78,8 +76,6 @@ final class TypoScriptConfigurationTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function setDataCalledTwoTimesDoesNotFail(): void
     {

--- a/Tests/Unit/DataStructures/AbstractObjectWithPublicAccessorsTest.php
+++ b/Tests/Unit/DataStructures/AbstractObjectWithPublicAccessorsTest.php
@@ -36,8 +36,6 @@ final class AbstractObjectWithPublicAccessorsTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function checkForNonEmptyKeyWithNonEmptyKeyIsAllowed(): void
     {

--- a/Tests/Unit/DataStructures/AbstractReadOnlyObjectWithAccessorsTest.php
+++ b/Tests/Unit/DataStructures/AbstractReadOnlyObjectWithAccessorsTest.php
@@ -36,8 +36,6 @@ final class AbstractReadOnlyObjectWithAccessorsTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function checkForNonEmptyKeyWithNonEmptyKeyIsAllowed(): void
     {

--- a/Tests/Unit/DataStructures/CollectionTest.php
+++ b/Tests/Unit/DataStructures/CollectionTest.php
@@ -858,8 +858,6 @@ final class CollectionTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function purgeCurrentWithEmptyListDoesNotFail(): void
     {
@@ -1066,8 +1064,6 @@ final class CollectionTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function addWithoutParentModelIsNoProblem(): void
     {

--- a/Tests/Unit/Geocoding/GeoCalculatorTest.php
+++ b/Tests/Unit/Geocoding/GeoCalculatorTest.php
@@ -425,8 +425,6 @@ final class GeoCalculatorTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function moveByRandomDistanceWithZeroNotThrowsException(): void
     {
@@ -539,8 +537,6 @@ final class GeoCalculatorTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function moveInRandomDirectionAndDistanceWithZeroNotThrowsException(): void
     {

--- a/Tests/Unit/Model/AbstractModelTest.php
+++ b/Tests/Unit/Model/AbstractModelTest.php
@@ -220,8 +220,6 @@ final class AbstractModelTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function setDataWithEmptyArrayIsAllowed(): void
     {
@@ -288,8 +286,6 @@ final class AbstractModelTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function resetDataCanBeCalledTwoTimes(): void
     {
@@ -655,8 +651,6 @@ final class AbstractModelTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function setUidForAModelWithoutUidDoesNotFail(): void
     {
@@ -783,8 +777,6 @@ final class AbstractModelTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function getUidOnDeadModelDoesNotFail(): void
     {
@@ -1179,8 +1171,6 @@ final class AbstractModelTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function setDataOnReadOnlyModelDoesNotFail(): void
     {
@@ -1381,8 +1371,6 @@ final class AbstractModelTest extends UnitTestCase
 
     /**
      * @test
-     *
-     * @doesNotPerformAssertions
      */
     public function setPageUidWithZeroPageUidNotThrowsException(): void
     {


### PR DESCRIPTION
With the current TYPO3 testing framework, the `tearDown()` method always performes some assertion. So this annotation does not make sense in this case.