### PR TITLE
[TASK] Drop obsolete suppression of FE cookies in testing FW

### DIFF
--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -685,7 +685,6 @@ final class TestingFramework
             throw new \InvalidArgumentException('$pageUid must be > 0.', 1_331_490_786);
         }
 
-        $this->suppressFrontEndCookies();
         $this->discardFakeFrontEnd();
 
         $this->setPageIndependentGlobalsForFakeFrontEnd();
@@ -867,18 +866,6 @@ routes: {  }";
         return $this->hasFakeFrontEnd;
     }
 
-    /**
-     * Makes sure that no FE login cookies will be sent.
-     */
-    private function suppressFrontEndCookies(): void
-    {
-        // avoid cookies from the phpMyAdmin extension
-        $GLOBALS['PHP_UNIT_TEST_RUNNING'] = true;
-
-        $_POST['FE_SESSION_KEY'] = '';
-        $_GET['FE_SESSION_KEY'] = '';
-    }
-
     // FE user activities
 
     /**
@@ -925,8 +912,6 @@ routes: {  }";
             $dataToSet['usergroup'] = $userGroups->getUids();
         }
 
-        $this->suppressFrontEndCookies();
-
         $frontEndUser = $this->getFrontEndController()->fe_user;
         $frontEndUser->createUserSession(['uid' => $userId, 'disableIPlock' => true]);
 
@@ -956,7 +941,6 @@ routes: {  }";
             return;
         }
 
-        $this->suppressFrontEndCookies();
         $frontEndUser = $this->getFrontEndController()->fe_user;
         $frontEndUser->logoff();
 


### PR DESCRIPTION
Nowadays, functional tests have their own environment, and hence there is no phpMyAdmin there. So there is no need to set `PHP_UNIT_TEST_RUNNING`.

Also, `FE_SESSION_KEY` got removed in TYPO3 9LTS:
https://docs.typo3.org/permalink/changelog:breaking-93002

Fixes #2193