### PR TITLE
[TASK] Add a missing `@doesNotPerformAssertions` annotation

### DIFF
--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -1529,6 +1529,8 @@ final class TestingFrameworkTest extends FunctionalTestCase
 
     /**
      * @test
+     *
+     * @doesNotPerformAssertions
      */
     public function logoutFrontEndUserCanBeCalledTwoTimes(): void
     {


### PR DESCRIPTION
This test indeed does not perform any assertions, and PHPUnit will complain about that fact without the annotation.