### PR TITLE
[TASK] Enable some more warnings in the functional tests

### DIFF
--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -2,24 +2,14 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          backupGlobals="true"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="../../.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
          cacheResult="false"
          colors="true"
-         convertDeprecationsToExceptions="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          failOnRisky="true"
          failOnWarning="true"
-         forceCoversAnnotation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         stopOnIncomplete="false"
-         stopOnSkipped="false"
-         verbose="false"
+         forceCoversAnnotation="true"
 >
+
     <php>
         <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
         <const name="TYPO3_MODE" value="BE"/>
@@ -29,7 +19,7 @@
                          Will always be done with next major version.
                          To still suppress warnings, notices and deprecations, do NOT define the constant at all.
          -->
-        <!--        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true"/>-->
+        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true"/>
         <ini name="display_errors" value="1"/>
         <env name="TYPO3_CONTEXT" value="Testing"/>
     </php>


### PR DESCRIPTION
Also drop configuration values that are the same as their corresponding default values.

Do not enable warnings for deprecations (and their output)
yet, though, as we cannot avoid some warnings about usage
of the deprecated `ObjectManager` in TYPO3 11LTS as the
warning is created in Core code. So that part needs to
wait until we have dropped support for TYPO3 11LTS.