### PR TITLE
[TASK] Disable TYPO3 12LTS/PHP 8.4 functionals with lowest deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,9 +254,9 @@ jobs:
           - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: highest
-          - typo3-version: "^12.4"
-            php-version: "8.4"
-            composer-dependencies: lowest
+#          - typo3-version: "^12.4"
+#            php-version: "8.4"
+#            composer-dependencies: lowest
           - typo3-version: "^12.4"
             php-version: "8.4"
             composer-dependencies: highest


### PR DESCRIPTION
The lowest versions of the dependencies have lots of warnings with PHP 8.4. So there is no point running tests with these warnings.