### PR TITLE
[BUGFIX] Use `executeStatement()` instead of `executeQuery()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Use `executeStatement()` instead of `executeQuery()` where appropriate (#2237)
+
 ## 6.2.0: View helper improvements and deprecations
 
 ### Added

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -1126,8 +1126,7 @@ routes: {  }";
 
         $connection = $this->getConnectionForTable($tableName);
         $query = 'UPDATE ' . $tableName . ' SET ' . $fieldName . '=' . $fieldName . '+1 WHERE uid=' . $uid;
-        $queryResult = $connection->executeQuery($query);
-        $numberOfAffectedRows = $queryResult->rowCount();
+        $numberOfAffectedRows = $connection->executeStatement($query);
         if ($numberOfAffectedRows === 0) {
             throw new \BadMethodCallException(
                 'The table ' . $tableName . ' does not contain a record with UID ' . $uid . '.',


### PR DESCRIPTION
`executeStatement()` should only be used for read queries.

For queries that manipulate the DB, `executeStatement()` should be used.

https://github.com/doctrine/dbal/issues/4607

Fixes #2169