### PR TITLE
[TASK] Make the Symfony development deps less fine-grained

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,9 +52,9 @@
 		"squizlabs/php_codesniffer": "4.0.1",
 		"ssch/typo3-rector": "2.15.2",
 		"ssch/typo3-rector-testing-framework": "2.0.1",
-		"symfony/console": "5.4.47 || 6.4.32 || 7.4.4",
-		"symfony/translation": "5.4.45 || 6.4.32 || 7.4.4",
-		"symfony/yaml": "5.4.45 || 6.4.30 || 7.4.1",
+		"symfony/console": "^5.4 || ^6.4 || ^7.4",
+		"symfony/translation": "^5.4 || ^6.4 || ^7.4",
+		"symfony/yaml": "^5.4 || ^6.4 || ^7.4",
 		"typo3/cms-extensionmanager": "^11.5 || ^12.4",
 		"typo3/coding-standards": "0.6.1 || 0.8.0",
 		"typo3/testing-framework": "7.1.1"


### PR DESCRIPTION
`composer require --dev "symfony/console:^5.4 ||^6.4 || ^7.4" "symfony/translation:^5.4 || ^6.4 || ^7.4" "symfony/yaml:^5.4 || ^6.4 || ^7.4"`

`composer normalize`