### PR TITLE
[CLEANUP] Polish `TestingFramework::createFakeFrontEnd()` a bit

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -291,6 +291,16 @@ parameters:
 			path: ../../Classes/Testing/TestingFramework.php
 
 		-
+			message: "#^Call to method setLogger\\(\\) on an unknown class ContentObjectRenderer\\.$#"
+			count: 1
+			path: ../../Classes/Testing/TestingFramework.php
+
+		-
+			message: "#^Call to method setRequest\\(\\) on an unknown class ContentObjectRenderer\\.$#"
+			count: 1
+			path: ../../Classes/Testing/TestingFramework.php
+
+		-
 			message: "#^Call to protected method unpack_uc\\(\\) of class TYPO3\\\\CMS\\\\Core\\\\Authentication\\\\AbstractUserAuthentication\\.$#"
 			count: 1
 			path: ../../Classes/Testing/TestingFramework.php
@@ -367,11 +377,6 @@ parameters:
 
 		-
 			message: "#^Method OliverKlee\\\\Oelib\\\\Testing\\\\TestingFramework\\:\\:getTcaForTable\\(\\) should return array\\<array\\<string, mixed\\>\\> but returns mixed\\.$#"
-			count: 1
-			path: ../../Classes/Testing/TestingFramework.php
-
-		-
-			message: "#^PHPDoc tag @var with type TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer is not subtype of type ContentObjectRenderer\\.$#"
 			count: 1
 			path: ../../Classes/Testing/TestingFramework.php
 

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -653,7 +653,7 @@ final class TestingFramework
         }
 
         $language = $site->getLanguageById(0);
-        $frontEnd = GeneralUtility::makeInstance(
+        $frontEndController = GeneralUtility::makeInstance(
             TypoScriptFrontendController::class,
             GeneralUtility::makeInstance(Context::class),
             $site,
@@ -661,21 +661,21 @@ final class TestingFramework
             new PageArguments($pageUid, '', []),
             $frontEndUser,
         );
-        $GLOBALS['TSFE'] = $frontEnd;
+        $GLOBALS['TSFE'] = $frontEndController;
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
-        $frontEnd->fe_user = $frontEndUser;
-        $frontEnd->id = $pageUid;
-        $frontEnd->determineId($request);
-        $frontEnd->config = [
+        $frontEndController->fe_user = $frontEndUser;
+        $frontEndController->id = $pageUid;
+        $frontEndController->determineId($request);
+        $frontEndController->config = [
             'config' => ['MP_disableTypolinkClosestMPvalue' => true, 'typolinkLinkAccessRestrictedPages' => true],
         ];
 
-        Locales::setSystemLocaleFromSiteLanguage($frontEnd->getLanguage());
+        Locales::setSystemLocaleFromSiteLanguage($frontEndController->getLanguage());
 
-        $frontEnd->newCObj();
-        /** @var ContentObjectRenderer $contentObject */
-        $contentObject = $frontEnd->cObj;
+        $frontEndController->newCObj();
+        $contentObject = $frontEndController->cObj;
+        \assert($contentObject instanceof ContentObjectRenderer);
         $contentObject->setLogger(new NullLogger());
         $contentObject->setRequest($request);
 

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -1572,12 +1572,12 @@ final class TestingFrameworkTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function createFakeFrontEndSetsFrontEndApplicationTypeInRequest(): void
+    public function createFakeFrontEndSetsRequestApplicationTypeToFrontEnd(): void
     {
         $pageUid = $this->subject->createFrontEndPage();
         $this->subject->createFakeFrontEnd($pageUid);
 
-        $request = $GLOBALS['TYPO3_REQUEST'];
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
         self::assertInstanceOf(ServerRequest::class, $request);
         self::assertSame(SystemEnvironmentBuilder::REQUESTTYPE_FE, $request->getAttribute('applicationType'));
     }
@@ -1585,26 +1585,25 @@ final class TestingFrameworkTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function createFakeFrontEndSetsLanguageInRequest(): void
+    public function createFakeFrontEndSetsRequestLanguage(): void
     {
         $pageUid = $this->subject->createFrontEndPage();
         $this->subject->createFakeFrontEnd($pageUid);
 
-        $request = $GLOBALS['TYPO3_REQUEST'];
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
         self::assertInstanceOf(ServerRequest::class, $request);
-
         self::assertInstanceOf(SiteLanguage::class, $request->getAttribute('language'));
     }
 
     /**
      * @test
      */
-    public function createFakeFrontEndSetsLanguageInRequestToDefault(): void
+    public function createFakeFrontEndSetsRequestLanguageToEnglish(): void
     {
         $pageUid = $this->subject->createFrontEndPage();
         $this->subject->createFakeFrontEnd($pageUid);
 
-        $request = $GLOBALS['TYPO3_REQUEST'];
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
         self::assertInstanceOf(ServerRequest::class, $request);
         $language = $request->getAttribute('language');
         self::assertInstanceOf(SiteLanguage::class, $language);


### PR DESCRIPTION
The PHPStan warnings are probably related to issues in `TypoScriptFrontendController`, not in our code.

Also polish the tests a bit.