### PR TITLE
[BUGFIX] Avoid the deprecated `determineId()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid the deprecated `determineId()` method in the testing framework (#2274)
+
 ## 6.2.1 Performance improvements, new record icon, deprecation fixes
 
 ### Added

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -663,7 +663,9 @@ final class TestingFramework
 
         $frontEndController->fe_user = $frontEndUser;
         $frontEndController->id = $pageUid;
-        $frontEndController->determineId($request);
+        if ((new Typo3Version())->getMajorVersion() <= 12) {
+            $frontEndController->determineId($request);
+        }
         $frontEndController->config = [
             'config' => ['MP_disableTypolinkClosestMPvalue' => true, 'typolinkLinkAccessRestrictedPages' => true],
         ];


### PR DESCRIPTION
Fixes #2273