### PR TITLE
[BUGFIX] Avoid `TypoScriptFrontendController::getLanguage()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Avoid the deprecated `TypoScriptFrontendController::getLanguage()` (#2278)
 - Avoid the deprecated `determineId()` method in the testing framework (#2274)
 
 ## 6.2.1 Performance improvements, new record icon, deprecation fixes

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -673,7 +673,7 @@ final class TestingFramework
             'config' => ['MP_disableTypolinkClosestMPvalue' => true, 'typolinkLinkAccessRestrictedPages' => true],
         ];
 
-        Locales::setSystemLocaleFromSiteLanguage($frontEndController->getLanguage());
+        Locales::setSystemLocaleFromSiteLanguage($language);
 
         $frontEndController->newCObj();
         $contentObject = $frontEndController->cObj;


### PR DESCRIPTION
This method gets removed in TYPO3 V13.