### PR TITLE
[FEATURE] Add `SystemEmailBuilder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Add `SystemEmailBuilder` (#2294)
 - Add `IfIsAdminViewHelper` (#2298)
 - Make the registries available via DI (#2292)
 - Use the new TypoScript parser in TYPO3 >= V12 (#2284)
@@ -19,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate `SystemEmailFromBuilder` (#2294)
 - Deprecate the configuration check (#2297)
 - Deprecate `::getInstance` in the registries (#2292)
 - Deprecate the static accessors of `ConfigurationRegistry`, `MapperRegistry`

--- a/Classes/Email/SystemEmailBuilder.php
+++ b/Classes/Email/SystemEmailBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Oelib\Email;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MailUtility;
+
+/**
+ * Creates a `GeneralEmailRole` with the default system email from name and email address.
+ *
+ * Use via DI.
+ */
+class SystemEmailBuilder
+{
+    public function build(): GeneralEmailRole
+    {
+        $email = MailUtility::getSystemFromAddress();
+        $name = MailUtility::getSystemFromName();
+        if (!\is_string($name)) {
+            $name = '';
+        }
+
+        return GeneralUtility::makeInstance(GeneralEmailRole::class, $email, $name);
+    }
+}

--- a/Classes/Email/SystemEmailFromBuilder.php
+++ b/Classes/Email/SystemEmailFromBuilder.php
@@ -9,6 +9,8 @@ use TYPO3\CMS\Core\Utility\MailUtility;
 
 /**
  * This class builds email subjects with the email data from the install tool.
+ *
+ * @deprecated Will be removed in oelib 7.0 in #2293. Use `SystemEmailBuilder` instead.
  */
 class SystemEmailFromBuilder
 {

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -11,6 +11,9 @@ services:
   OliverKlee\Oelib\Configuration\ConfigurationRegistry:
     public: true
 
+  OliverKlee\Oelib\Email\SystemEmailBuilder:
+    public: true
+
   OliverKlee\Oelib\Mapper\MapperRegistry:
     public: true
 

--- a/Tests/Functional/Email/SystemEmailBuilderTest.php
+++ b/Tests/Functional/Email/SystemEmailBuilderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Oelib\Tests\Functional\Email;
+
+use OliverKlee\Oelib\Email\GeneralEmailRole;
+use OliverKlee\Oelib\Email\SystemEmailBuilder;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * @covers \OliverKlee\Oelib\Email\SystemEmailBuilder
+ */
+final class SystemEmailBuilderTest extends FunctionalTestCase
+{
+    protected bool $initializeDatabase = false;
+
+    protected array $testExtensionsToLoad = ['oliverklee/oelib'];
+
+    private SystemEmailBuilder $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new SystemEmailBuilder();
+    }
+
+    /**
+     * @test
+     */
+    public function isAvailableViaContainer(): void
+    {
+        $instance = $this->get(SystemEmailBuilder::class);
+
+        self::assertInstanceOf(SystemEmailBuilder::class, $instance);
+    }
+
+    /**
+     * @test
+     */
+    public function buildWithConfiguredFromAddressReturnsGeneralEmailRoleWithDefaultFromAddress(): void
+    {
+        self::assertIsArray($GLOBALS['TYPO3_CONF_VARS']);
+        self::assertIsArray($GLOBALS['TYPO3_CONF_VARS']['MAIL']);
+        $fromAddress = 'someone@example.com';
+        $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromAddress'] = $fromAddress;
+
+        $result = $this->subject->build();
+
+        self::assertInstanceOf(GeneralEmailRole::class, $result);
+        self::assertSame($fromAddress, $result->getEmailAddress());
+    }
+
+    /**
+     * @test
+     */
+    public function buildWithoutConfiguredFromAddressReturnsGeneralEmailRoleWithNoReplyAddress(): void
+    {
+        self::assertIsArray($GLOBALS['TYPO3_CONF_VARS']);
+        self::assertIsArray($GLOBALS['TYPO3_CONF_VARS']['MAIL']);
+        $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromAddress'] = '';
+
+        $result = $this->subject->build();
+
+        self::assertInstanceOf(GeneralEmailRole::class, $result);
+        self::assertStringStartsWith('no-reply@', $result->getEmailAddress());
+    }
+
+    /**
+     * @test
+     */
+    public function buildWithConfiguredFromNameReturnsGeneralEmailRoleWithDefaultFromName(): void
+    {
+        self::assertIsArray($GLOBALS['TYPO3_CONF_VARS']);
+        self::assertIsArray($GLOBALS['TYPO3_CONF_VARS']['MAIL']);
+        $fromName = 'Dungeon Crawler Carl';
+        $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromName'] = $fromName;
+
+        $result = $this->subject->build();
+
+        self::assertInstanceOf(GeneralEmailRole::class, $result);
+        self::assertSame($fromName, $result->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function buildWithoutConfiguredFromNameReturnsGeneralEmailRoleWithEmptyFromName(): void
+    {
+        self::assertIsArray($GLOBALS['TYPO3_CONF_VARS']);
+        self::assertIsArray($GLOBALS['TYPO3_CONF_VARS']['MAIL']);
+        $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromName'] = '';
+
+        $result = $this->subject->build();
+
+        self::assertInstanceOf(GeneralEmailRole::class, $result);
+        self::assertSame('', $result->getName());
+    }
+}


### PR DESCRIPTION
This new class is a streamlined and DI-capable revamp of `SystemEmailFromBuilder`, which now is deprecated.