### PR TITLE
[TASK] Deprecate the configuration check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Deprecate the configuration check (#2297)
 - Deprecate `::getInstance` in the registries (#2292)
 - Deprecate the static accessors of `ConfigurationRegistry`, `MapperRegistry`
   and `TemplateRegistry` (#2291)

--- a/Classes/Configuration/AbstractConfigurationCheck.php
+++ b/Classes/Configuration/AbstractConfigurationCheck.php
@@ -14,6 +14,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * This class can check any configuration, e.g., TypoScript, Flexforms or extension manager.
  *
  * To use this class, override the `checkAllConfigurationValues` method to call the available `check*` methods.
+ *
+ * @deprecated will be removed in oelib 7.0 in #2296
  */
 abstract class AbstractConfigurationCheck
 {

--- a/Classes/ViewHelpers/AbstractConfigurationCheckViewHelper.php
+++ b/Classes/ViewHelpers/AbstractConfigurationCheckViewHelper.php
@@ -15,12 +15,14 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  * Usage:
  * 1. Create a corresponding configuration check class.
  * 2. Extend this view helper in your extension.
- * 4. Override the method getExtensionKey() to return your extension key (without the `tx_` prefix).
- * 3. Override the method getConfigurationCheckClassName() to return the name of your configuration check class.
+ * 4. Override the method `getExtensionKey()` to return your extension key (without the `tx_` prefix).
+ * 3. Override the method `getConfigurationCheckClassName()` to return the name of your configuration check class.
  * 4. If your TypoScript configuration namespace is different from `plugin.tx_<your extension key>.settings`
- *    override the method getConfigurationNamespace() to return your namespace.
+ *    override the method `getConfigurationNamespace()` to return your namespace.
  *
  * @template C of AbstractConfigurationCheck
+ *
+ * @deprecated will be removed in oelib 7.0 in #2296
  */
 abstract class AbstractConfigurationCheckViewHelper extends AbstractViewHelper
 {


### PR DESCRIPTION
While providing integrators helpful messages, the configuration check was problematic from an architecture perspective. To make future development and TYPO3 compability easier, this feature will be dropped and now is deprecated.

Fixes #2295