### PR TITLE
[TASK] Only provide real TypoScript to the fake FE in TYPO3 V12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
+- Only provide real TypoScript to the fake FE in TYPO3 V12 (#2302)
 - Deprecate `SystemEmailFromBuilder` (#2294)
 - Deprecate the configuration check (#2297)
 - Deprecate `::getInstance` in the registries (#2292)

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -1149,7 +1149,7 @@ routes: {  }";
         $sysTemplateRepository = GeneralUtility::makeInstance(SysTemplateRepository::class);
         $sysTemplateRows = $sysTemplateRepository->getSysTemplateRowsByRootline($rootline, $request);
 
-        if ($sysTemplateRows !== []) {
+        if ($sysTemplateRows !== [] && (new Typo3Version())->getMajorVersion() === 12) {
             $newRequest = $controller->getFromCache($request);
         } else {
             $newRequest = $request->withAttribute('frontend.typoscript', $this->buildEmptyTypoScript());

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -1698,8 +1698,8 @@ final class TestingFrameworkTest extends FunctionalTestCase
      */
     public function createFakeFrontEndProvidesRequestTypoScriptWithTypoScriptSetupFromPage(): void
     {
-        if ((new Typo3Version())->getMajorVersion() < 12) {
-            self::markTestSkipped('The request typoscript object is only available in TYPO3 v12 and above.');
+        if ((new Typo3Version())->getMajorVersion() !== 12) {
+            self::markTestSkipped('This feature is only available in TYPO3 v12.');
         }
 
         $this->importCSVDataSet(__DIR__ . '/Fixtures/createFakeFrontEnd/PageWithTemplate.csv');


### PR DESCRIPTION
For TYPO3 < V12, this feature is not available, and for TYPO3 > 12, the used Core functionality is not available anymore.