### PR TITLE
[FEATURE] Expose the non-static `ConfigurationRegistry` getter

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -406,6 +406,11 @@ parameters:
 			path: ../../Classes/ViewHelpers/AbstractConfigurationCheckViewHelper.php
 
 		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: ../../Tests/Functional/Configuration/ConfigurationRegistryTest.php
+
+		-
 			message: "#^PHPDoc tag @var with type OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Model\\\\Fixtures\\\\TestingModel is not subtype of type OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Model\\\\Fixtures\\\\TestingChildModel\\.$#"
 			count: 1
 			path: ../../Tests/Functional/Mapper/AbstractDataMapperTest.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Expose the non-static `ConfigurationRegistry` getter (#2311)
 - Expose the non-static `MapperRegistry` getter/setter (#2320)
 - Add `SystemEmailBuilder` (#2294)
 - Add `IfIsAdminViewHelper` (#2298)

--- a/Classes/Configuration/ConfigurationRegistry.php
+++ b/Classes/Configuration/ConfigurationRegistry.php
@@ -92,7 +92,7 @@ class ConfigurationRegistry
      *
      * @return ConfigurationInterface the configuration for the given namespace
      */
-    private function getByNamespace(string $namespace): ConfigurationInterface
+    public function getByNamespace(string $namespace): ConfigurationInterface
     {
         $this->checkForNonEmptyNamespace($namespace);
 

--- a/Tests/Functional/Configuration/ConfigurationRegistryTest.php
+++ b/Tests/Functional/Configuration/ConfigurationRegistryTest.php
@@ -34,6 +34,7 @@ final class ConfigurationRegistryTest extends FunctionalTestCase
     protected function tearDown(): void
     {
         ConfigurationRegistry::purgeInstance();
+        PageFinder::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
 
         parent::tearDown();
@@ -114,7 +115,9 @@ final class ConfigurationRegistryTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/Fixtures/ConfigurationRegistry/PageWithTemplate.csv');
 
         $this->testingFramework->createFakeFrontEnd(1);
-        PageFinder::getInstance()->forceSource(PageFinder::SOURCE_FRONT_END);
+        $pageFinder = PageFinder::getInstance();
+        $pageFinder->setPageUid(1);
+        $pageFinder->forceSource(PageFinder::SOURCE_FRONT_END);
 
         self::assertSame(
             42,
@@ -134,5 +137,101 @@ final class ConfigurationRegistryTest extends FunctionalTestCase
         ConfigurationRegistry::getInstance()->set('plugin.tx_oelib', $configuration);
 
         self::assertSame($configuration, ConfigurationRegistry::get('plugin.tx_oelib'));
+    }
+
+    /**
+     * @test
+     */
+    public function getByNamespaceForNonEmptyNamespaceReturnsConfigurationInstance(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ConfigurationRegistry/PageWithTemplate.csv');
+        PageFinder::getInstance()->setPageUid(1);
+
+        self::assertInstanceOf(
+            TypoScriptConfiguration::class,
+            $this->subject->getByNamespace('plugin.tx_oelib'),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getByNamespaceForTheSameNamespaceCalledTwoTimesReturnsTheSameInstance(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ConfigurationRegistry/PageWithTemplate.csv');
+        PageFinder::getInstance()->setPageUid(1);
+
+        self::assertSame(
+            $this->subject->getByNamespace('plugin.tx_oelib'),
+            $this->subject->getByNamespace('plugin.tx_oelib'),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getByNamespaceReturnsDataFromTypoScriptSetupFromManuallySetPage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ConfigurationRegistry/PageWithTemplate.csv');
+        PageFinder::getInstance()->setPageUid(1);
+
+        self::assertSame(
+            42,
+            $this->subject->getByNamespace('plugin.tx_oelib')->getAsInteger('test'),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getByNamespaceReturnsDataFromTypoScriptSetupFromBackEndPage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ConfigurationRegistry/PageWithTemplate.csv');
+        $_GET['id'] = 1;
+
+        PageFinder::getInstance()->forceSource(PageFinder::SOURCE_BACK_END);
+
+        self::assertSame(
+            42,
+            $this->subject->getByNamespace('plugin.tx_oelib')->getAsInteger('test'),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getByNamespaceReturnsDataFromTypoScriptSetupFromFrontEndPage(): void
+    {
+        self::markTestIncomplete(
+            'This test currently fails if run after getReturnsDataFromTypoScriptSetupFromFrontEndPage '
+            . 'as the TypoScript parsing runs into an endless loop. There is some cross-pollution between these tests, '
+            . 'and we need to find out how to properly clean up after them to avoid that.',
+        );
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ConfigurationRegistry/PageWithTemplate.csv');
+
+        $this->testingFramework->createFakeFrontEnd(1);
+        $pageFinder = PageFinder::getInstance();
+        $pageFinder->setPageUid(1);
+        $pageFinder->forceSource(PageFinder::SOURCE_FRONT_END);
+
+        self::assertSame(
+            42,
+            $this->subject->getByNamespace('plugin.tx_oelib')->getAsInteger('test'),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getByNamespaceAfterSetReturnsManuallySetConfigurationEvenIfThereIsAPage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ConfigurationRegistry/PageWithTemplate.csv');
+        PageFinder::getInstance()->setPageUid(1);
+
+        $configuration = new DummyConfiguration();
+        $this->subject->set('plugin.tx_oelib', $configuration);
+
+        self::assertSame($configuration, $this->subject->getByNamespace('plugin.tx_oelib'));
     }
 }

--- a/Tests/Unit/Configuration/ConfigurationRegistryTest.php
+++ b/Tests/Unit/Configuration/ConfigurationRegistryTest.php
@@ -63,8 +63,6 @@ final class ConfigurationRegistryTest extends UnitTestCase
         );
     }
 
-    // Test concerning get and set
-
     /**
      * @test
      */
@@ -122,5 +120,42 @@ final class ConfigurationRegistryTest extends UnitTestCase
     {
         $this->subject->set('foo', new DummyConfiguration());
         $this->subject->set('foo', new DummyConfiguration());
+    }
+
+    /**
+     * @test
+     */
+    public function getByNamespaceForEmptyNamespaceThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$namespace must not be empty.');
+        $this->expectExceptionCode(1_331_318_549);
+
+        // @phpstan-ignore-next-line We are explicitly checking for a contract violation here.
+        $this->subject->getByNamespace('');
+    }
+
+    /**
+     * @test
+     */
+    public function getByNamespaceAfterSetWithTypoScriptConfigurationReturnsTheSetInstance(): void
+    {
+        $configuration = new TypoScriptConfiguration();
+
+        $this->subject->set('foo', $configuration);
+
+        self::assertSame($configuration, $this->subject->getByNamespace('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function getByNamespaceAfterSetWithDummyConfigurationReturnsTheSetInstance(): void
+    {
+        $configuration = new DummyConfiguration();
+
+        $this->subject->set('foo', $configuration);
+
+        self::assertSame($configuration, $this->subject->getByNamespace('foo'));
     }
 }


### PR DESCRIPTION
This actually makes it possible to avoid using the deprecated static accessors.

Part of #2305