### PR TITLE
[BUGFIX] Properly discard the registry singletons in the tests

### DIFF
--- a/Tests/Functional/Configuration/ConfigurationRegistryTest.php
+++ b/Tests/Functional/Configuration/ConfigurationRegistryTest.php
@@ -28,7 +28,9 @@ final class ConfigurationRegistryTest extends FunctionalTestCase
 
     protected function tearDown(): void
     {
+        ConfigurationRegistry::purgeInstance();
         $this->testingFramework->cleanUpWithoutDatabase();
+
         parent::tearDown();
     }
 

--- a/Tests/Functional/Mapper/MapperRegistryTest.php
+++ b/Tests/Functional/Mapper/MapperRegistryTest.php
@@ -16,6 +16,13 @@ final class MapperRegistryTest extends FunctionalTestCase
 
     protected array $testExtensionsToLoad = ['oliverklee/oelib'];
 
+    protected function tearDown(): void
+    {
+        MapperRegistry::purgeInstance();
+
+        parent::tearDown();
+    }
+
     /**
      * @test
      */

--- a/Tests/Functional/Templating/TemplateRegistryTest.php
+++ b/Tests/Functional/Templating/TemplateRegistryTest.php
@@ -17,6 +17,13 @@ final class TemplateRegistryTest extends FunctionalTestCase
 
     protected bool $initializeDatabase = false;
 
+    protected function tearDown(): void
+    {
+        TemplateRegistry::purgeInstance();
+
+        parent::tearDown();
+    }
+
     /**
      * @test
      */

--- a/Tests/Unit/Configuration/ConfigurationRegistryTest.php
+++ b/Tests/Unit/Configuration/ConfigurationRegistryTest.php
@@ -14,6 +14,13 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class ConfigurationRegistryTest extends UnitTestCase
 {
+    protected function tearDown(): void
+    {
+        ConfigurationRegistry::purgeInstance();
+
+        parent::tearDown();
+    }
+
     /**
      * @test
      */

--- a/Tests/Unit/Mapper/MapperRegistryTest.php
+++ b/Tests/Unit/Mapper/MapperRegistryTest.php
@@ -17,6 +17,7 @@ final class MapperRegistryTest extends UnitTestCase
     protected function tearDown(): void
     {
         MapperRegistry::purgeInstance();
+
         parent::tearDown();
     }
 

--- a/Tests/Unit/Templating/TemplateRegistryTest.php
+++ b/Tests/Unit/Templating/TemplateRegistryTest.php
@@ -13,6 +13,13 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class TemplateRegistryTest extends UnitTestCase
 {
+    protected function tearDown(): void
+    {
+        TemplateRegistry::purgeInstance();
+
+        parent::tearDown();
+    }
+
     // Tests concerning the Singleton property
 
     /**


### PR DESCRIPTION
This keeps the tests from leaving any leftovers lying aroung after running.