### PR TITLE
[FEATURE] Expose the non-static `MapperRegistry` getter/setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Expose the non-static `MapperRegistry` getter/setter (#2320)
 - Add `SystemEmailBuilder` (#2294)
 - Add `IfIsAdminViewHelper` (#2298)
 - Make the registries available via DI (#2292)

--- a/Classes/Mapper/MapperRegistry.php
+++ b/Classes/Mapper/MapperRegistry.php
@@ -81,7 +81,7 @@ class MapperRegistry
      *
      * @throws \InvalidArgumentException if there is no such mapper
      */
-    private function getByClassName(string $className): AbstractDataMapper
+    public function getByClassName(string $className): AbstractDataMapper
     {
         if ($className === '') {
             throw new \InvalidArgumentException('$className must not be empty.', 1_331_488_868);
@@ -139,7 +139,7 @@ class MapperRegistry
      * @throws \InvalidArgumentException
      * @throws \BadMethodCallException
      */
-    private function setByClassName(string $className, AbstractDataMapper $mapper): void
+    public function setByClassName(string $className, AbstractDataMapper $mapper): void
     {
         if (!$mapper instanceof $className) {
             throw new \InvalidArgumentException(

--- a/Tests/Unit/Mapper/MapperRegistryTest.php
+++ b/Tests/Unit/Mapper/MapperRegistryTest.php
@@ -14,6 +14,15 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class MapperRegistryTest extends UnitTestCase
 {
+    private MapperRegistry $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new MapperRegistry();
+    }
+
     protected function tearDown(): void
     {
         MapperRegistry::purgeInstance();
@@ -119,6 +128,65 @@ final class MapperRegistryTest extends UnitTestCase
     /**
      * @test
      */
+    public function getByClassNameForEmptyKeyThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$className must not be empty.');
+        $this->expectExceptionCode(1331488868);
+
+        // @phpstan-ignore-next-line We explicitly check for contract violations here.
+        $this->subject->getByClassName('');
+    }
+
+    /**
+     * @test
+     */
+    public function getByClassNameForInexistentClassThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No mapper class');
+        $this->expectExceptionCode(1632844178);
+
+        // @phpstan-ignore-next-line We're testing a contract violation here on purpose.
+        $this->subject->getByClassName('InexistentMapper');
+    }
+
+    /**
+     * @test
+     */
+    public function getByClassNameForExistingClassReturnsObjectOfRequestedClass(): void
+    {
+        self::assertInstanceOf(TestingMapper::class, $this->subject->getByClassName(TestingMapper::class));
+    }
+
+    /**
+     * @test
+     */
+    public function getByClassNameForExistingClassCalledTwoTimesReturnsTheSameInstance(): void
+    {
+        self::assertSame(
+            $this->subject->getByClassName(TestingMapper::class),
+            $this->subject->getByClassName(TestingMapper::class),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getByClassNameReturnsMapperSetViaSetByClassName(): void
+    {
+        $mapper = new TestingMapper();
+        $this->subject->setByClassName(TestingMapper::class, $mapper);
+
+        self::assertSame(
+            $mapper,
+            $this->subject->getByClassName(TestingMapper::class),
+        );
+    }
+
+    /**
+     * @test
+     */
     public function setThrowsExceptionForMismatchingWrapperClass(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -142,5 +210,33 @@ final class MapperRegistryTest extends UnitTestCase
 
         $mapper = new TestingMapper();
         MapperRegistry::set(TestingMapper::class, $mapper);
+    }
+
+    /**
+     * @test
+     */
+    public function setByClassNameThrowsExceptionForMismatchingWrapperClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided mapper is not an instance of');
+        $this->expectExceptionCode(1331488915);
+
+        $mapper = new TestingMapper();
+        $this->subject->setByClassName(TestingChildMapper::class, $mapper);
+    }
+
+    /**
+     * @test
+     */
+    public function setByClassNameThrowsExceptionIfTheMapperTypeAlreadyIsRegistered(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Overwriting existing mappers is not allowed.');
+        $this->expectExceptionCode(1331488928);
+
+        $this->subject->getByClassName(TestingMapper::class);
+
+        $mapper = new TestingMapper();
+        $this->subject->setByClassName(TestingMapper::class, $mapper);
     }
 }


### PR DESCRIPTION
This makes it actually possible to use the `MapperRegistry` via DI.

Part of #2305