### PR TITLE
[BUGFIX] Avoid duplicate singleton instances of the registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Expose the non-static `MapperRegistry` getter/setter (#2320)
 - Add `SystemEmailBuilder` (#2294)
 - Add `IfIsAdminViewHelper` (#2298)
-- Make the registries available via DI (#2292)
+- Make the registries available via DI (#2292, #2321)
 - Use the new TypoScript parser in TYPO3 >= V12 (#2284)
 - Provide the fake frontend request with TypoScript (#2282)
 - Provide the fake frontend with a rootline (#2277)

--- a/Classes/Configuration/ConfigurationRegistry.php
+++ b/Classes/Configuration/ConfigurationRegistry.php
@@ -44,16 +44,12 @@ class ConfigurationRegistry
     }
 
     /**
-     * Returns an instance of this class.
-     *
-     * @return ConfigurationRegistry the current Singleton instance
-     *
      * @deprecated #2287 will be removed in oelib 7.0; use DI instead
      */
-    public static function getInstance(): ConfigurationRegistry
+    public static function getInstance(): self
     {
         if (!self::$instance instanceof self) {
-            self::$instance = new ConfigurationRegistry();
+            self::$instance = GeneralUtility::makeInstance(self::class);
         }
 
         return self::$instance;

--- a/Classes/Mapper/MapperRegistry.php
+++ b/Classes/Mapper/MapperRegistry.php
@@ -24,16 +24,12 @@ class MapperRegistry
     private array $mappers = [];
 
     /**
-     * Returns an instance of this class.
-     *
-     * @return MapperRegistry the current Singleton instance
-     *
      * @deprecated #2287 will be removed in oelib 7.0; use DI instead
      */
-    public static function getInstance(): MapperRegistry
+    public static function getInstance(): self
     {
         if (!self::$instance instanceof self) {
-            self::$instance = new MapperRegistry();
+            self::$instance = GeneralUtility::makeInstance(self::class);
         }
 
         return self::$instance;

--- a/Classes/Templating/TemplateRegistry.php
+++ b/Classes/Templating/TemplateRegistry.php
@@ -22,16 +22,12 @@ class TemplateRegistry
     private array $templates = [];
 
     /**
-     * Returns an instance of this class.
-     *
-     * @return TemplateRegistry the current Singleton instance
-     *
      * @deprecated #2287 will be removed in oelib 7.0; use DI instead
      */
-    public static function getInstance(): TemplateRegistry
+    public static function getInstance(): self
     {
         if (!self::$instance instanceof self) {
-            self::$instance = new TemplateRegistry();
+            self::$instance = GeneralUtility::makeInstance(self::class);
         }
 
         return self::$instance;


### PR DESCRIPTION
Ensure that using the deprecated `::getInstance()` method returns the same instance that the DI container provides by using `GeneralUtility::makeInstance()` instead of `new`.