### PR TITLE
[BUGFIX] Disable caching for the fake frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Disable caching for the fake frontend (#2322)
 - Avoid undefined array access in `SystemEmailFromBuilder` (#2310)
 - Provide the request to `newCObj()` for TYPO3 V13 (#2281)
 - Avoid the deprecated `TypoScriptFrontendController::getLanguage()` (#2278)

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -661,6 +661,7 @@ final class TestingFramework
             $pageArguments,
             $frontEndUser,
         );
+        $frontEndController->set_no_cache('fake frontend', true);
         $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pageUid);
         $rootline = $rootlineUtility->get();
         $frontEndController->rootLine = $rootline;

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -1340,6 +1340,19 @@ final class TestingFrameworkTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function createFakeFrontEndDisablesFrontEndCaching(): void
+    {
+        $pageUid = $this->subject->createFrontEndPage();
+        $this->subject->createFakeFrontEnd($pageUid);
+
+        $frontEndController = $GLOBALS['TSFE'];
+        self::assertInstanceOf(TypoScriptFrontendController::class, $frontEndController);
+        self::assertTrue($frontEndController->no_cache);
+    }
+
+    /**
+     * @test
+     */
     public function createFakeFrontEndCreatesFrontEndUser(): void
     {
         $pageUid = $this->subject->createFrontEndPage();


### PR DESCRIPTION
There is no point in enabling caching for a fake frontend that will be discarded after the test is done.