### PR TITLE
[BUGFIX] Avoid inserting empty DB rows in the testing framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fix cross-DBMS compatibility in the testing framework (#2341)
+
 ## 6.3.0: DI-capable registries, new ViewHelper, better fake FE, deprecations
 
 ### Added

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -212,6 +212,9 @@ final class TestingFramework
         foreach ($rawData as $key => $value) {
             $dataToInsert[$key] = \is_bool($value) ? (int)$value : $value;
         }
+        if ($dataToInsert === []) {
+            $dataToInsert['pid'] = 0;
+        }
 
         return $dataToInsert;
     }


### PR DESCRIPTION
Postgres and SQLite do not allow inserting empty rows into the database. By ensuring that we have at least the `pid` column if there is no other data, we restore compatibility with Postgres and SQLite for the testing framework.

Fixes #2340