### PR TITLE
[BUGFIX] Make the tests more DBMS-independent

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -411,6 +411,11 @@ parameters:
 			path: ../../Tests/Functional/Configuration/ConfigurationRegistryTest.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 5
+			path: ../../Tests/Functional/Mapper/AbstractDataMapperTest.php
+
+		-
 			message: "#^PHPDoc tag @var with type OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Model\\\\Fixtures\\\\TestingModel is not subtype of type OliverKlee\\\\Oelib\\\\Tests\\\\Unit\\\\Model\\\\Fixtures\\\\TestingChildModel\\.$#"
 			count: 1
 			path: ../../Tests/Functional/Mapper/AbstractDataMapperTest.php
@@ -438,6 +443,11 @@ parameters:
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotSame\\(\\) with 0 and int\\<1, max\\> will always evaluate to true\\.$#"
 			count: 16
+			path: ../../Tests/Functional/Testing/TestingFrameworkTest.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 3
 			path: ../../Tests/Functional/Testing/TestingFrameworkTest.php
 
 		-

--- a/Tests/Functional/Mapper/AbstractDataMapperTest.php
+++ b/Tests/Functional/Mapper/AbstractDataMapperTest.php
@@ -1987,7 +1987,7 @@ final class AbstractDataMapperTest extends FunctionalTestCase
 
         self::assertIsArray($data);
         self::assertArrayHasKey($propertyName, $data);
-        self::assertSame(42, $data[$propertyName]);
+        self::assertSame(42, (int)$data[$propertyName]);
     }
 
     /**
@@ -2027,7 +2027,7 @@ final class AbstractDataMapperTest extends FunctionalTestCase
 
         self::assertIsArray($data);
         self::assertArrayHasKey($propertyName, $data);
-        self::assertSame($expectedValue, $data[$propertyName]);
+        self::assertSame($expectedValue, (int)$data[$propertyName]);
     }
 
     /**
@@ -2685,7 +2685,7 @@ final class AbstractDataMapperTest extends FunctionalTestCase
         $queryResult = $relationConnection->executeQuery($query, ['uid' => $component2->getUid(), 'deleted' => 1]);
         $row = $queryResult->fetchAssociative();
         self::assertIsArray($row);
-        self::assertSame(1, $row['count']);
+        self::assertSame(1, (int)$row['count']);
     }
 
     /**
@@ -3294,7 +3294,7 @@ final class AbstractDataMapperTest extends FunctionalTestCase
         $queryResult = $connection->executeQuery($query, ['uid' => $uid, 'deleted' => 1]);
         $row = $queryResult->fetchAssociative();
         self::assertIsArray($row);
-        self::assertSame(1, $row['count']);
+        self::assertSame(1, (int)$row['count']);
     }
 
     /**
@@ -3340,7 +3340,7 @@ final class AbstractDataMapperTest extends FunctionalTestCase
         $queryResult = $relationConnection->executeQuery($query, ['uid' => $relatedUid, 'deleted' => 1]);
         $row = $queryResult->fetchAssociative();
         self::assertIsArray($row);
-        self::assertSame(1, $row['count']);
+        self::assertSame(1, (int)$row['count']);
     }
 
     /**

--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -191,7 +191,7 @@ final class TestingFrameworkTest extends FunctionalTestCase
         $queryResult = $connection->executeQuery($query, ['uid' => $uid, 'hidden' => 1]);
         $row = $queryResult->fetchAssociative();
         self::assertIsArray($row);
-        self::assertSame(1, $row['count']);
+        self::assertSame(1, (int)$row['count']);
     }
 
     /**
@@ -207,7 +207,7 @@ final class TestingFrameworkTest extends FunctionalTestCase
         $queryResult = $connection->executeQuery($query, ['uid' => $uid, 'deleted' => 1]);
         $row = $queryResult->fetchAssociative();
         self::assertIsArray($row);
-        self::assertSame(1, $row['count']);
+        self::assertSame(1, (int)$row['count']);
     }
 
     /**
@@ -1432,7 +1432,7 @@ final class TestingFrameworkTest extends FunctionalTestCase
         $this->subject->createFakeFrontEnd($pageUid);
 
         $rootline = $this->getFrontEndController()->rootLine;
-        self::assertSame($pageUid, $rootline[0]['uid']);
+        self::assertSame($pageUid, (int)$rootline[0]['uid']);
     }
 
     /**


### PR DESCRIPTION
On some setups, SQLite returns int column results as strings. Add the according casts.