### PR TITLE
[BUGFIX] Drop tests that rely on undocumented DBMS-specifics

### DIFF
--- a/Classes/Mapper/FrontEndUserMapper.php
+++ b/Classes/Mapper/FrontEndUserMapper.php
@@ -38,9 +38,6 @@ class FrontEndUserMapper extends AbstractDataMapper
      */
     public function findByUserName(string $username): FrontEndUser
     {
-        /** @var FrontEndUser $result */
-        $result = $this->findOneByKey('username', $username);
-
-        return $result;
+        return $this->findOneByKey('username', $username);
     }
 }

--- a/Tests/Functional/Mapper/FrontEndUserMapperTest.php
+++ b/Tests/Functional/Mapper/FrontEndUserMapperTest.php
@@ -108,45 +108,11 @@ final class FrontEndUserMapperTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function findByUserNameWithUppercasedNameOfExistingLowercasedUserReturnsModelWithThatUid(): void
-    {
-        $username = 'max.doe';
-        $connection = $this->getConnectionPool()->getConnectionForTable('fe_users');
-        $connection->insert('fe_users', ['username' => $username]);
-
-        $uid = (int)$connection->lastInsertId('fe_users');
-
-        self::assertSame(
-            $uid,
-            $this->subject->findByUserName(strtoupper($username))->getUid(),
-        );
-    }
-
-    /**
-     * @test
-     */
     public function findByUserNameWithUppercasedNameOfExistingUppercasedUserReturnsModelWithThatUid(): void
     {
         $username = 'MAX.DOE';
         $connection = $this->getConnectionPool()->getConnectionForTable('fe_users');
         $connection->insert('fe_users', ['username' => $username]);
-
-        $uid = (int)$connection->lastInsertId('fe_users');
-
-        self::assertSame(
-            $uid,
-            $this->subject->findByUserName($username)->getUid(),
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function findByUserNameWithLowercasedNameOfExistingUppercasedUserReturnsModelWithThatUid(): void
-    {
-        $username = 'max.doe';
-        $connection = $this->getConnectionPool()->getConnectionForTable('fe_users');
-        $connection->insert('fe_users', ['username' => \strtoupper($username)]);
 
         $uid = (int)$connection->lastInsertId('fe_users');
 


### PR DESCRIPTION
Non-case-sensitive matching is not cross-DBMS-compatible, and it's also not a guaranteed behavior. So remove the tests for that.

Also drop a redundant type annotation.