### PR TITLE
[TASK] Skip a test in TYPO3 V13 that only makes sense in < 13

### DIFF
--- a/Tests/Functional/Testing/TestingFrameworkTest.php
+++ b/Tests/Functional/Testing/TestingFrameworkTest.php
@@ -1363,6 +1363,10 @@ final class TestingFrameworkTest extends FunctionalTestCase
      */
     public function createFakeFrontEndDisablesFrontEndCaching(): void
     {
+        if ((new Typo3Version())->getMajorVersion() >= 13) {
+            self::markTestSkipped('TypoScriptFrontendController::no_cache got removed in TYPO3 13LTS.');
+        }
+
         $pageUid = $this->subject->createFrontEndPage();
         $this->subject->createFakeFrontEnd($pageUid);
 


### PR DESCRIPTION
`TypoScriptFrontendController::no_cache` got removed in TYPO3 13LTS. So a test accessing that property does not make sense to be run with TYPO3 13LTS.

Fixes #2330