### PR TITLE
[BUGFIX] Get the `BackendConfigurationManager` via DI if possible

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -26,6 +26,11 @@ parameters:
 			path: ../../Classes/Configuration/ConfigurationRegistry.php
 
 		-
+			message: "#^Method TYPO3\\\\CMS\\\\Extbase\\\\Configuration\\\\BackendConfigurationManager\\:\\:getTypoScriptSetup\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: ../../Classes/Configuration/ConfigurationRegistry.php
+
+		-
 			message: "#^Parameter \\#1 \\$haystack of method OliverKlee\\\\Oelib\\\\Configuration\\\\FlexformsConfiguration\\:\\:getFromArray\\(\\) expects array\\<array\\<int\\|string, mixed\\>\\|int\\|string\\>, array\\<int\\|string, mixed\\> given\\.$#"
 			count: 1
 			path: ../../Classes/Configuration/FlexformsConfiguration.php

--- a/Build/rector/config.php
+++ b/Build/rector/config.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
@@ -78,4 +79,7 @@ return RectorConfig::configure()
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ])
     ->withSkip([
+        RemoveExtraParametersRector::class => [
+            'Classes/Configuration/ConfigurationRegistry.php',
+        ],
     ]);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Receive the `BackendConfigurationManager` via DI (#2358)
 - Disable caching for the fake frontend (#2322)
 - Avoid undefined array access in `SystemEmailFromBuilder` (#2310)
 - Provide the request to `newCObj()` for TYPO3 V13 (#2281)

--- a/Classes/Configuration/ConfigurationRegistry.php
+++ b/Classes/Configuration/ConfigurationRegistry.php
@@ -22,6 +22,8 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class ConfigurationRegistry
 {
+    private BackendConfigurationManager $backendConfigurationManager;
+
     /**
      * @deprecated #2287 will be removed in oelib 7.0
      */
@@ -31,6 +33,11 @@ class ConfigurationRegistry
      * @var array<non-empty-string, ConfigurationInterface> already created configurations (by namespace)
      */
     private array $configurations = [];
+
+    public function __construct(BackendConfigurationManager $backendConfigurationManager)
+    {
+        $this->backendConfigurationManager = $backendConfigurationManager;
+    }
 
     /**
      * Destructs a configuration for a given namespace and drops the reference to it.
@@ -194,10 +201,21 @@ class ConfigurationRegistry
         $queryParams['id'] = $pageUid;
         $request = $request->withQueryParams($queryParams);
 
-        $configurationManager = GeneralUtility::makeInstance(BackendConfigurationManager::class);
-        $configurationManager->setRequest($request);
+        $configurationManager = $this->getBackendConfigurationManager($request);
 
-        return $configurationManager->getTypoScriptSetup();
+        return ((new Typo3Version())->getMajorVersion() <= 12)
+            ? $configurationManager->getTypoScriptSetup()
+            : $configurationManager->getTypoScriptSetup($request);
+    }
+
+    private function getBackendConfigurationManager(ServerRequestInterface $request): BackendConfigurationManager
+    {
+        $configurationManager = $this->backendConfigurationManager;
+        if ((new Typo3Version())->getMajorVersion() <= 12) {
+            $configurationManager->setRequest($request);
+        }
+
+        return $configurationManager;
     }
 
     /**


### PR DESCRIPTION
In TYPO3 13LTS, the `BackendConfigurationManager` class is not `public` anymore and hence cannot be created using `GeneralUtility::makeInstance()` anymore.

Fixes #2323
Fixes #2326
