### PR TITLE
[BUGFIX] Release the lock after creating a fake FE

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -406,11 +406,6 @@ parameters:
 			path: ../../Classes/ViewHelpers/AbstractConfigurationCheckViewHelper.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: ../../Tests/Functional/Configuration/ConfigurationRegistryTest.php
-
-		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 5
 			path: ../../Tests/Functional/Mapper/AbstractDataMapperTest.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Release the lock after creating a fake FE (#2359)
 - Receive the `BackendConfigurationManager` via DI (#2358)
 - Disable caching for the fake frontend (#2322)
 - Avoid undefined array access in `SystemEmailFromBuilder` (#2310)

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\ServerRequestFactory;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\Locales;
+use TYPO3\CMS\Core\Locking\ResourceMutex;
 use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\TypoScript\AST\Node\RootNode;
@@ -701,6 +702,7 @@ final class TestingFramework
         if ((new Typo3Version())->getMajorVersion() >= 12) {
             $request = $request->withAttribute('currentContentObject', $contentObject);
             $request = $this->addTypoScriptToRequest($frontEndController, $rootline, $request);
+            GeneralUtility::makeInstance(ResourceMutex::class)->releaseLock('pages');
         }
         $GLOBALS['TYPO3_REQUEST'] = $request;
         $contentObject->setRequest($request);

--- a/Tests/Functional/Configuration/ConfigurationRegistryTest.php
+++ b/Tests/Functional/Configuration/ConfigurationRegistryTest.php
@@ -319,12 +319,27 @@ final class ConfigurationRegistryTest extends FunctionalTestCase
      */
     public function getByNamespaceReturnsDataFromTypoScriptSetupFromFrontEndPage(): void
     {
-        self::markTestIncomplete(
-            'This test currently fails if run after getReturnsDataFromTypoScriptSetupFromFrontEndPage '
-            . 'as the TypoScript parsing runs into an endless loop. There is some cross-pollution between these tests, '
-            . 'and we need to find out how to properly clean up after them to avoid that.',
-        );
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ConfigurationRegistry/PageWithTemplate.csv');
 
+        $this->testingFramework->createFakeFrontEnd(1);
+        $pageFinder = PageFinder::getInstance();
+        $pageFinder->setPageUid(1);
+        $pageFinder->forceSource(PageFinder::SOURCE_FRONT_END);
+
+        self::assertSame(
+            42,
+            $this->subject->getByNamespace('plugin.tx_oelib')->getAsInteger('test'),
+        );
+    }
+
+    /**
+     * This is the same as the previous test, but we are testing that the previous tests does not leave any locks
+     * in our way.
+     *
+     * @test
+     */
+    public function getByNamespaceReturnsDataFromTypoScriptSetupFromFrontEndPageAgain(): void
+    {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/ConfigurationRegistry/PageWithTemplate.csv');
 
         $this->testingFramework->createFakeFrontEnd(1);


### PR DESCRIPTION
This avoids an endless loop when the fake FE is created with TypoScript for the same page UID twice.

Fixes #2325