### PR TITLE
[TASK] Drop the static accessors of the registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
+- Drop the static accessors of the registries (#2384)
 - Drop returning the page UID in `createFakeFrontend` (#2383)
 - Drop `ExtbaseConfiguration` (#2379)
 - Drop the `Time` interface (#2378)

--- a/Classes/Configuration/ConfigurationRegistry.php
+++ b/Classes/Configuration/ConfigurationRegistry.php
@@ -78,22 +78,6 @@ class ConfigurationRegistry
      * @param non-empty-string $namespace the name of a configuration namespace, e.g., "plugin.tx_oelib"
      *
      * @return ConfigurationInterface the configuration for the given namespace
-     *
-     * @see getByNamespace
-     *
-     * @deprecated use `getByNamespace` instead. #2290 will be removed in oelib 7.0
-     */
-    public static function get(string $namespace): ConfigurationInterface
-    {
-        return self::getInstance()->getByNamespace($namespace);
-    }
-
-    /**
-     * Retrieves a `Configuration` by namespace.
-     *
-     * @param non-empty-string $namespace the name of a configuration namespace, e.g., "plugin.tx_oelib"
-     *
-     * @return ConfigurationInterface the configuration for the given namespace
      */
     public function getByNamespace(string $namespace): ConfigurationInterface
     {

--- a/Classes/Mapper/AbstractDataMapper.php
+++ b/Classes/Mapper/AbstractDataMapper.php
@@ -1237,6 +1237,6 @@ abstract class AbstractDataMapper
      */
     private function getRelationMapperByKey(string $key): AbstractDataMapper
     {
-        return MapperRegistry::get($this->relations[$key]);
+        return MapperRegistry::getInstance()->getByClassName($this->relations[$key]);
     }
 }

--- a/Classes/Mapper/MapperRegistry.php
+++ b/Classes/Mapper/MapperRegistry.php
@@ -56,26 +56,6 @@ class MapperRegistry
      * @return M the mapper instance of the provided class
      *
      * @throws \InvalidArgumentException if there is no such mapper
-     *
-     * @see getByClassName
-     *
-     * @deprecated use `getByClassName` instead. #2290 will be removed in oelib 7.0
-     */
-    public static function get(string $className): AbstractDataMapper
-    {
-        return self::getInstance()->getByClassName($className);
-    }
-
-    /**
-     * Retrieves a dataMapper by class name.
-     *
-     * @template M of AbstractDataMapper
-     *
-     * @param class-string<M> $className the name of an existing mapper class
-     *
-     * @return M the mapper instance of the provided class
-     *
-     * @throws \InvalidArgumentException if there is no such mapper
      */
     public function getByClassName(string $className): AbstractDataMapper
     {
@@ -99,27 +79,6 @@ class MapperRegistry
         }
 
         return $mapper;
-    }
-
-    /**
-     * Sets a mapper that can be returned via get.
-     *
-     * This function is a static public convenience wrapper for setByClassName.
-     *
-     * This function is to be used for testing purposes only.
-     *
-     * @template M of AbstractDataMapper
-     *
-     * @param class-string<M> $className the class name of the mapper to set
-     * @param M $mapper the mapper to set, must be an instance of `$className`
-     *
-     * @see setByClassName
-     *
-     * @deprecated use `setByClassName` instead. #2290 will be removed in oelib 7.0
-     */
-    public static function set(string $className, AbstractDataMapper $mapper): void
-    {
-        self::getInstance()->setByClassName($className, $mapper);
     }
 
     /**

--- a/Classes/Templating/TemplateRegistry.php
+++ b/Classes/Templating/TemplateRegistry.php
@@ -50,27 +50,6 @@ class TemplateRegistry
      * If the template file name is empty, no template file will be used for
      * that template.
      *
-     * @param string $templateFileName the file name of the template to retrieve, may not be empty to get a template
-     *        that is not related to a template file.
-     *
-     * @return Template the template for the given template file name
-     *
-     * @see getByFileName
-     *
-     * @deprecated use `getByFileName` instead. #2290 will be removed in oelib 7.0
-     */
-    public static function get(string $templateFileName): Template
-    {
-        return self::getInstance()->getByFileName($templateFileName);
-    }
-
-    /**
-     * Creates a new template for a provided template file name with an already
-     * parsed the template file.
-     *
-     * If the template file name is empty, no template file will be used for
-     * that template.
-     *
      * @param string $fileName the file name of the template to retrieve, may not be empty to get a template that
      *        is not related to a template file
      *

--- a/Classes/Testing/TestingFramework.php
+++ b/Classes/Testing/TestingFramework.php
@@ -755,7 +755,7 @@ routes: {  }";
             );
         }
 
-        $mapper = MapperRegistry::get(FrontEndUserMapper::class);
+        $mapper = MapperRegistry::getInstance()->getByClassName(FrontEndUserMapper::class);
         // loads the model from database if it is a ghost
         $mapper->existsModel($userId);
 

--- a/Tests/Functional/Mapper/AbstractDataMapperTest.php
+++ b/Tests/Functional/Mapper/AbstractDataMapperTest.php
@@ -39,7 +39,7 @@ final class AbstractDataMapperTest extends FunctionalTestCase
         $dateAspect = new DateTimeAspect(new \DateTimeImmutable('2018-04-26 12:42:23'));
         $this->get(Context::class)->setAspect('date', $dateAspect);
 
-        $this->subject = MapperRegistry::get(TestingMapper::class);
+        $this->subject = $this->get(MapperRegistry::class)->getByClassName(TestingMapper::class);
     }
 
     protected function tearDown(): void

--- a/Tests/Functional/Model/AbstractModelTest.php
+++ b/Tests/Functional/Model/AbstractModelTest.php
@@ -28,7 +28,7 @@ final class AbstractModelTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->dataMapper = MapperRegistry::get(TestingMapper::class);
+        $this->dataMapper = $this->get(MapperRegistry::class)->getByClassName(TestingMapper::class);
 
         $uid = $this->createTestRecord();
         $this->subject = $this->dataMapper->find($uid);

--- a/Tests/Functional/Templating/TemplateRegistryTest.php
+++ b/Tests/Functional/Templating/TemplateRegistryTest.php
@@ -44,41 +44,6 @@ final class TemplateRegistryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getForExistingTemplateFileNameReturnsTemplate(): void
-    {
-        self::assertInstanceOf(
-            Template::class,
-            TemplateRegistry::get('EXT:oelib/Tests/Functional/Templating/Fixtures/Template.html'),
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function getForExistingTemplateFileNameCalledTwoTimesReturnsNewInstance(): void
-    {
-        self::assertNotSame(
-            TemplateRegistry::get('EXT:oelib/Tests/Functional/Templating/Fixtures/Template.html'),
-            TemplateRegistry::get('EXT:oelib/Tests/Functional/Templating/Fixtures/Template.html'),
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function getForExistingTemplateFileNameReturnsProcessedTemplate(): void
-    {
-        $template = TemplateRegistry::get('EXT:oelib/Tests/Functional/Templating/Fixtures/Template.html');
-
-        self::assertSame(
-            "Hello world!\n",
-            $template->getSubpart(),
-        );
-    }
-
-    /**
-     * @test
-     */
     public function getByFileNameForExistingTemplateFileNameReturnsTemplate(): void
     {
         self::assertInstanceOf(

--- a/Tests/Unit/Mapper/AbstractDataMapperTest.php
+++ b/Tests/Unit/Mapper/AbstractDataMapperTest.php
@@ -404,9 +404,7 @@ final class AbstractDataMapperTest extends UnitTestCase
         $this->expectExceptionMessage('$model must have a UID.');
         $this->expectExceptionCode(1_331_319_915);
 
-        $model = new TestingModel();
-
-        MapperRegistry::get(TestingChildMapper::class)->findAllByRelation($model, 'parent');
+        (new TestingChildMapper())->findAllByRelation(new TestingModel(), 'parent');
     }
 
     /**

--- a/Tests/Unit/Mapper/MapperRegistryTest.php
+++ b/Tests/Unit/Mapper/MapperRegistryTest.php
@@ -69,65 +69,6 @@ final class MapperRegistryTest extends UnitTestCase
     /**
      * @test
      */
-    public function getForEmptyKeyThrowsException(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('$className must not be empty.');
-        $this->expectExceptionCode(1331488868);
-
-        // @phpstan-ignore-next-line We explicitly check for contract violations here.
-        MapperRegistry::get('');
-    }
-
-    /**
-     * @test
-     */
-    public function getForInexistentClassThrowsException(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('No mapper class');
-        $this->expectExceptionCode(1632844178);
-
-        // @phpstan-ignore-next-line We're testing a contract violation here on purpose.
-        MapperRegistry::get('InexistentMapper');
-    }
-
-    /**
-     * @test
-     */
-    public function getForExistingClassReturnsObjectOfRequestedClass(): void
-    {
-        self::assertInstanceOf(TestingMapper::class, MapperRegistry::get(TestingMapper::class));
-    }
-
-    /**
-     * @test
-     */
-    public function getForExistingClassCalledTwoTimesReturnsTheSameInstance(): void
-    {
-        self::assertSame(
-            MapperRegistry::get(TestingMapper::class),
-            MapperRegistry::get(TestingMapper::class),
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function getReturnsMapperSetViaSet(): void
-    {
-        $mapper = new TestingMapper();
-        MapperRegistry::set(TestingMapper::class, $mapper);
-
-        self::assertSame(
-            $mapper,
-            MapperRegistry::get(TestingMapper::class),
-        );
-    }
-
-    /**
-     * @test
-     */
     public function getByClassNameForEmptyKeyThrowsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -182,34 +123,6 @@ final class MapperRegistryTest extends UnitTestCase
             $mapper,
             $this->subject->getByClassName(TestingMapper::class),
         );
-    }
-
-    /**
-     * @test
-     */
-    public function setThrowsExceptionForMismatchingWrapperClass(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The provided mapper is not an instance of');
-        $this->expectExceptionCode(1331488915);
-
-        $mapper = new TestingMapper();
-        MapperRegistry::set(TestingChildMapper::class, $mapper);
-    }
-
-    /**
-     * @test
-     */
-    public function setThrowsExceptionIfTheMapperTypeAlreadyIsRegistered(): void
-    {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Overwriting existing mappers is not allowed.');
-        $this->expectExceptionCode(1331488928);
-
-        MapperRegistry::get(TestingMapper::class);
-
-        $mapper = new TestingMapper();
-        MapperRegistry::set(TestingMapper::class, $mapper);
     }
 
     /**

--- a/Tests/Unit/Templating/TemplateRegistryTest.php
+++ b/Tests/Unit/Templating/TemplateRegistryTest.php
@@ -68,28 +68,6 @@ final class TemplateRegistryTest extends UnitTestCase
     /**
      * @test
      */
-    public function getForEmptyTemplateFileNameReturnsTemplateInstance(): void
-    {
-        self::assertInstanceOf(
-            Template::class,
-            TemplateRegistry::get(''),
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function getForEmptyTemplateFileNameCalledTwoTimesReturnsNewInstance(): void
-    {
-        self::assertNotSame(
-            TemplateRegistry::get(''),
-            TemplateRegistry::get(''),
-        );
-    }
-
-    /**
-     * @test
-     */
     public function getByFileNameForEmptyTemplateFileNameReturnsTemplateInstance(): void
     {
         self::assertInstanceOf(


### PR DESCRIPTION
- `ConfigurationRegistry::get()`
- `MapperRegistry::get()`
- `MapperRegistry::set()`
- `TemplateRegistry::get()`

Fixes #2290