### PR TITLE
[TASK] Move PHPCov from Phive to Composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,10 +3,8 @@
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore
-/.phive/ export-ignore
 /Build/ export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /Resources/Private/Patches/ export-ignore
 /Tests/ export-ignore
 /crowdin.yml export-ignore
-/tools/ export-ignore binary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
       - dependency-type: "development"
     ignore:
       - dependency-name: "doctrine/dbal"
+      - dependency-name: "phpunit/phpcov"
+        versions: [ ">= 10.0" ]
       - dependency-name: "phpunit/phpunit"
         versions: [ ">= 10" ]
       - dependency-name: "sjbr/static-info-tables"

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -27,11 +27,9 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           ini-file: development
-          tools: composer:v2, phive
+          tools: composer:v2
           extensions: mysqli
           coverage: xdebug
-      - name: Install development tools
-        run: phive --no-progress install --trust-gpg-keys D8406D0D82947747293778314AA394086372C20A
       - name: Show Composer version
         run: composer --version
       - name: Show the Composer configuration

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@
 /composer.lock
 /generate-documentation.sh
 /nbproject
-/tools
 /var

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<phive xmlns="https://phar.io/phive">
-  <phar name="phpcov" version="^9.0.2" installed="9.0.2" location="./tools/phpcov" copy="false"/>
-</phive>

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
 		"phpstan/phpstan": "1.12.32",
 		"phpstan/phpstan-phpunit": "1.4.2",
 		"phpstan/phpstan-strict-rules": "1.6.2",
+		"phpunit/phpcov": "9.0.2",
 		"phpunit/phpunit": "10.5.64",
 		"rector/type-perfect": "1.0.0",
 		"saschaegerer/phpstan-typo3": "1.10.2",
@@ -122,7 +123,7 @@
 		],
 		"check:coverage:merge": [
 			"@coverage:create-directories",
-			"tools/phpcov merge --clover=./build/logs/clover.xml ./.Build/coverage/"
+			"phpcov merge --clover=./build/logs/clover.xml ./.Build/coverage/"
 		],
 		"check:coverage:unit": [
 			"@coverage:create-directories",
@@ -165,10 +166,8 @@
 		"prepare-release": [
 			"rm -rf .Build",
 			"rm -rf .github",
-			"rm -rf .phive",
 			"rm -rf Build",
 			"rm -rf Tests",
-			"rm -rf tools",
 			"rm .editorconfig",
 			"rm .gitattributes",
 			"rm .gitignore",


### PR DESCRIPTION
Now that we require PHP >= 8.1, we can use PHPCov as a Composer dependency again.

This allows us to stop using PHIVE in addition to Composer as a dependency manager.

```
./Build/Scripts/runTests.sh -s composer req --dev phpunit/phpcov:9.0.2
```